### PR TITLE
Enable travis to make sure 'mkdocs build' always works.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: python
+install:
+  - pip install -r requirements.txt
+script:
+  - mkdocs build


### PR DESCRIPTION
This adds a basic travis configuration for build validation.