### PR TITLE
Fix the community links to use markdown, also fix the sTEAL url.

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -8,50 +8,50 @@ Below is a categorized list of projects that are using the Algorand blockchain a
 
 | Name| Description |
 |------|------|
-| <center>![](./imgs/goalseekericon.png)</center><center> <a href="https://goalseeker.purestake.io/algorand/mainnet" target="_blank">GoalSeeker</a></center> | GoalSeeker makes it easier than ever to view critical network statistics, browse recently created blocks, search for transactions and accounts in previous blocks, and review activity related to Algorand Standard Assets (ASAs). This Block Explorer is maintained by [PureStake](https://www.purestake.com/). |
-| <center>![](./imgs/algoexplorer.png)</center><center> <a href="https://algoexplorer.io/" target="_blank">Algo Explorer</a></center> | Algoexplorer is a complete Algorand blockchain explorer created by [Rand Labs](https://randlabs.io/).|
+| <center>![](./imgs/goalseekericon.png)</center><center> [GoalSeeker](https://goalseeker.purestake.io/algorand/mainnet)</center> | GoalSeeker makes it easier than ever to view critical network statistics, browse recently created blocks, search for transactions and accounts in previous blocks, and review activity related to Algorand Standard Assets (ASAs). This Block Explorer is maintained by [PureStake](https://www.purestake.com/). |
+| <center>![](./imgs/algoexplorer.png)</center><center> [Algo Explorer](https://algoexplorer.io/)</center> | Algoexplorer is a complete Algorand blockchain explorer created by [Rand Labs](https://randlabs.io/).|
 
 
 # Wallets
 
 | Name| Description |
 |------|------|
-| <center>![](./imgs/myalgo.png)</center><center> <a href="https://wallet.myalgo.com/" target="_blank">My Algo</a></center> | My Algo provides an interface to interact with the Algorand Blockchain created by [Rand Labs](https://randlabs.io/)|
-| <center><a href="https://github.com/RileyGe/algo-wallet" target="_blank">Algo Wallet</a></center> | A cross platform wallet built using the [Avalonia](https://avaloniaui.net/) UI. This wallets can be used on Windows, MacOS and Lunix and the Avaloni UI provides experimental support for iOS and Android. The library is Open Sourced (GNU) and is built in C#.|
+| <center>![](./imgs/myalgo.png)</center><center> [My Algo](https://wallet.myalgo.com/)</center> | My Algo provides an interface to interact with the Algorand Blockchain created by [Rand Labs](https://randlabs.io/)|
+| <center>[Algo Wallet](https://github.com/RileyGe/algo-wallet)</center> | A cross platform wallet built using the [Avalonia](https://avaloniaui.net/) UI. This wallets can be used on Windows, MacOS and Lunix and the Avaloni UI provides experimental support for iOS and Android. The library is Open Sourced (GNU) and is built in C#.|
 
 # API Services
 | Name| Description |
 |------|------|
-<center>![](./imgs/purestakelogo.png)</center><center> <a href="https://www.purestake.com/blog/algorand-rest-api-purestake/" target="_blank">PureStake API Service</a></center> | PureStake's API service makes it easy to quickly get up-and-running on the Algorand network. The service builds upon PureStake’s existing infrastructure platform to provide developers with easy-to-use access to native Algorand REST APIs. |
+<center>![](./imgs/purestakelogo.png)</center><center> [PureStake API Service](https://www.purestake.com/blog/algorand-rest-api-purestake/)</center> | PureStake's API service makes it easy to quickly get up-and-running on the Algorand network. The service builds upon PureStake’s existing infrastructure platform to provide developers with easy-to-use access to native Algorand REST APIs. |
 
 # SDKs
 | Name| Description |
 |------|------|
-| <center><a href="https://github.com/mraof/rust-algorand-sdk" target="_blank">Rust SDK</center></a> | RUST implementation of Algorand's REST API.|
-| <center><a href="https://github.com/RileyGe/dotnet-algorand-sdk" target="_blank">.Net SDK</a></center> | This libary is built with C# and provides Algorand 2.0 features and is compliant with .Net Standard 2.0.
+| <center>[Rust SDK](https://github.com/mraof/rust-algorand-sdk) | RUST implementation of Algorand's REST API.|
+| <center>[.NET SDK](https://github.com/RileyGe/dotnet-algorand-sdk)</center> | This libary is built with C# and provides Algorand 2.0 features and is compliant with .NET Standard 2.0.
 
 # API Wrappers
 | Name| Description |
 |------|------|
-| <center><a href="https://www.npmjs.com/package/simplealgo" target="_blank">Simple Algo</a> </center>| Simple Algo is an npm package that supports JavaScript and TypeScript. The package allows a user to interact with the Algorand protocol using standalone functions and API calls for account and blockchain information. |
+| <center>[Simple Algo](https://www.npmjs.com/package/simplealgo) </center>| Simple Algo is an npm package that supports JavaScript and TypeScript. The package allows a user to interact with the Algorand protocol using standalone functions and API calls for account and blockchain information. |
 
 # Smart Contract Utilities and Libraries
 | Name| Description |
 |------|------|
-| <center><a href="https://github.com/algorand/pyteal" target="_blank">PyTeal</a></center> | PyTeal is a Python language binding program for ASC1. PyTeal allows developer to express TEAL-based smart contract logic using Python. This dev tool abstracts TEAL and does type-checking at contraction time.|
-| <center><a href"https://github.com/algorand/tealviewer" target="_blank">sTEAL</a></center> | sTEAL is a tool written in (Racket) Scheme to help developers write TEAL templates and contracts. sTEAL allows developers to write an expression tree in Racket to represent a TEAL program. It then prints that tree into TEAL assembly. sTEAL supports a few rudimentary quality-of-life features, including variable-length arguments and templating. |
-| <center><a href"https://github.com/algorand/tealviewer" target="_blank">tealviewer</a></center> | tealviewer is a graphical tool for understanding how transaction parameters are checked by a given TEAL program.|
-| <center><a href"https://github.com/algorand/messagepack-debugger" target="_blank">MessagePack Debugger</a></center> | View and compare messagepack encoded objects. |
+| <center>[PyTeal](https://github.com/algorand/pyteal)</center> | PyTeal is a Python language binding program for ASC1. PyTeal allows developer to express TEAL-based smart contract logic using Python. This dev tool abstracts TEAL and does type-checking at contraction time.|
+| <center>[sTEAL](https://github.com/derbear/steal)</center> | sTEAL is a tool written in (Racket) Scheme to help developers write TEAL templates and contracts. sTEAL allows developers to write an expression tree in Racket to represent a TEAL program. It then prints that tree into TEAL assembly. sTEAL supports a few rudimentary quality-of-life features, including variable-length arguments and templating. |
+| <center>[tealviewer](https://github.com/algorand/tealviewer)</center> | tealviewer is a graphical tool for understanding how transaction parameters are checked by a given TEAL program.|
+| <center>[MessagePack Debugger](https://github.com/algorand/messagepack-debugger)</center> | View and compare messagepack encoded objects. |
 
 
 # Framework Components
 | Name| Description |
 |------|------|
-| <center><a href="https://www.npmjs.com/package/react-algorand" target="_blank">React-Algorand</a></center> | React-Alogrand is an npm package that allows a user to create simple wallet applications for pay transactions, scheduled transactions, interactive UI with rendered metadata for processing transactions and can be configured for both mainnet and testnet. |
-| <center><a href="https://github.com/mmitrasish/algorand-sdk-react-component" target="_blank">Algorand-React-Component</a></center> | A set of reusable functional React components for creating and signing transactions, writing to the notefield of a transaction, multisig transactions, offline account generation and mnemonic account recover. This tool acts a wrapper to the Algorand JavaScript SDK. |
+| <center>[React-Algorand](https://www.npmjs.com/package/react-algorand)</center> | React-Alogrand is an npm package that allows a user to create simple wallet applications for pay transactions, scheduled transactions, interactive UI with rendered metadata for processing transactions and can be configured for both mainnet and testnet. |
+| <center>[Algorand-React-Component](https://github.com/mmitrasish/algorand-sdk-react-component)</center> | A set of reusable functional React components for creating and signing transactions, writing to the notefield of a transaction, multisig transactions, offline account generation and mnemonic account recover. This tool acts a wrapper to the Algorand JavaScript SDK. |
 
 
 # Applications
 | Name| Description |
 |------|------|
-| <center><a href="https://github.com/Man-Jain/TrackAlgo" target="_blank">TrackAlgo</a></center> | TrackAlgo is a proof of concept materials tracking application that leverages the "note" field of a payment transaction to store metadata about an item, including things like coordinates and temperature. This showcases how an IoT application would be used in conjunction with the Algorand blockchain. |
+| <center>[TrackAlgo](https://github.com/Man-Jain/TrackAlgo)</center> | TrackAlgo is a proof of concept materials tracking application that leverages the "note" field of a payment transaction to store metadata about an item, including things like coordinates and temperature. This showcases how an IoT application would be used in conjunction with the Algorand blockchain. |


### PR DESCRIPTION
Noticed that I couldn't click on some of these links (Linux, Firefox/Chrome). Noticed that they were using HTML instead of Markdown, switching it seems to fix the problem.

While I was testing the changes I noticed that the sTEAL url was wrong (found the correct url and updated it), and the messagepack-debugger repo was prive (was able to fix that as well).