### PR TITLE
Modify comparison table title to align with previous topic title

### DIFF
--- a/docs/build-apps/setup.md
+++ b/docs/build-apps/setup.md
@@ -83,7 +83,7 @@ $ cat $ALGORAND_DATA/algod.token
 
 <center>*Side-by-Side Comparison*</center>
 
- || Use a third-party service | Bootstrap with s3 | Run your own node |
+ || Use a third-party service | Use Docker Sandbox | Run your own node |
 :-- |:-------------:| :-------------: | :-------------: |
 **Time**         | **Seconds** - Just signup| **Minutes** - Same as running a node with no catchup	| **Days** - need to wait for node to catchup
 **Trust**         | 1 party       | 1 party	| Yourself 


### PR DESCRIPTION
The `How do I obtain an algod address and token?` section contains three options : 
1. Use a third-party service
1. Use Docker Sandbox
1. Run your own node

But the side-by-side comparison doesn't have the 2nd title matching the original topic.