### PR TITLE
Update the betanet details

### DIFF
--- a/docs/reference/algorand-networks/betanet.md
+++ b/docs/reference/algorand-networks/betanet.md
@@ -1,10 +1,10 @@
 title: BetaNet
 
 # Version
-`v2.0.10.beta`
+`v2.0.11.beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.0.10-beta
+https://github.com/algorand/go-algorand/releases/tag/v2.0.11-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
Update the betanet details from 2.0.10 -> 2.0.11

Do not merge 2.0.11 release date - 2/25/20 10:30am est. 