### PR TITLE
Eric/add note about dns bootstrap config (#90)

### DIFF
--- a/docs/run-a-node/operations/switch_networks.md
+++ b/docs/run-a-node/operations/switch_networks.md
@@ -64,3 +64,19 @@ The process can be disabled or stoped using `systemctl` commands.
 sudo systemctl stop algorand@$(systemd-escape ${ALGORAND_DATA})
 sudo systemctl disable algorand@$(systemd-escape ${ALGORAND_DATA})
 ```
+
+# DNS Configuration for betanet
+For the `betanet` network, when installing a new node or relay, make the following modification to the `config.json` file located in the node's data directory. 
+First, if there is not a config.json, make a copy of the config.json.example file.  
+```
+cp config.json.example config.json
+```
+Then edit the config.json file and replace the line
+``` 
+"DNSBootstrapID": "<network>.algorand.network",
+```
+with 
+``` 
+"DNSBootstrapID": "<network>.algodev.network",
+```
+This modification to the `DNSBootstrapID` is only required for the `betanet` network.

--- a/docs/run-a-node/setup/install.md
+++ b/docs/run-a-node/setup/install.md
@@ -53,6 +53,8 @@ tar -xf install_master_darwin-amd64.tar.gz
 ```
 When the installer runs, it will pull down the latest update package from S3 and install it. The `-n` option above tells the installer to not auto-start the node. If the installation succeeds the node will need to be started manually described later in this [guide](#start-node). 
 
+!!! info
+    When installing the `rel/beta` release, specify the beta channel `-c beta`
 
 # Installing with Debian
 Nodes have been verified on Ubuntu 18.04. Other Debian-based distros should work as well (use apt-get install rather than apt install).
@@ -226,3 +228,19 @@ Add a line that looks like this (run update.sh every hour, on the half-hour, of 
 ```
 30 * * * * /home/user/node/update.sh -d /home/user/node/data >/home/user/node/update.log 2>&1
 ```
+
+# DNS Configuration for betanet
+For the `betanet` network, when installing a new node or relay, make the following modification to the `config.json` file located in the node's data directory. 
+First, if there is not a config.json, make a copy of the config.json.example file.  
+```
+cp config.json.example config.json
+```
+Then edit the config.json file and replace the line
+``` 
+"DNSBootstrapID": "<network>.algorand.network",
+```
+with 
+``` 
+"DNSBootstrapID": "<network>.algodev.network",
+```
+This modification to the `DNSBootstrapID` is only required for the `betanet` network.


### PR DESCRIPTION
* Added instructions for overriding default DNSBootstrapId for networks devnet and betanet.

* Removed reference to devnet.  Added a note about how to use the channel beta for installing beta net.

* Fixed typo in info.

Co-authored-by: JasonWeathersby <jasonweathersby@outlook.com>