### PR TITLE
Added an About section to the docs with links to license and contribu…

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -6,4 +6,4 @@ arrange:
   - reference
   - algorand_consensus.md
   - community.md
-
+  - about.md

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,13 @@
+title: About
+
+# License
+
+The Algorand Developer Documentation is licensed under an [MIT license](https://github.com/algorand/docs/blob/master/LICENSE.md). 
+
+# Contributing
+
+Learn how you can contribute by reading the [Contributing Guide](https://github.com/algorand/docs/blob/master/CONTRIBUTING.md) located in the [docs repository](https://github.com/algorand/docs) on Github. 
+
+# Attributions
+
+This documentation uses [MkDocs](https://www.mkdocs.org/) and [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/).


### PR DESCRIPTION
# Summary
Added an About section to the docs that is accessible via a new side menu item entitled "About". This ensures that people can find the Contributing guide and license information via search on the Dev Portal.

See screenshot rendering below:
![AddAbout](https://user-images.githubusercontent.com/45209375/82603356-83f1c300-9b80-11ea-8dc9-245444858ed4.png)

# Alternatives Considered 
I considered adding a nested About menu item that had separate pages for the Contributing Guide and the License, but decided against for the following reasons: 

1. The contributing guide and license info are more often found in the root directory of the Github repo, which means we would need to replicate them underneath the docs repo. This could lead to unnecessary churn (e.g. remembering to update both instead of just one).
2. A contributor is required to visit and work through Github to make a contribution so linking them out of the prod docs to the repo itself upon interest in contributing is a logical user flow.


