### PR TITLE
Added links to full code under each of the snippets.

### DIFF
--- a/docs/features/asa.md
+++ b/docs/features/asa.md
@@ -250,6 +250,8 @@ Create assets using either the SDKs or `goal`. When using the SDKs supply all cr
 goal asset create --creator <address> --total 1000 --unitname <unit-name> --asseturl "https://path/to/my/asset/details" --decimals 0   -d data
 ```
 
+[See complete code...](#complete-code-example)
+
 **See also**
 
 - [Anatomy of an Asset Creation Transaction](./transactions/index.md#create-an-asset)
@@ -378,6 +380,8 @@ After an asset has been created only the manager, reserve, freeze and reserve ac
 ``` goal tab="goal"  
 goal asset config  --manager <address> --new-reserve <address> --assetid <asset-id> -d data 
 ```
+
+[See complete code...](#complete-code-example)
 
 **See also**
 
@@ -524,6 +528,8 @@ Before an account can receive a specific asset it must opt-in to receive it. An 
 goal asset send -a 0 --asset <asset-name>  -f <opt-in-account> -t <opt-in-account> --creator <asset-creator>  -d data
 ```
 
+[See complete code...](#complete-code-example)
+
 **See also**
 
 - [Structure of an Asset Opt-In Transaction](./transactions/index.md#opt-in-to-an-asset)
@@ -657,6 +663,8 @@ Assets can be transferred between accounts that have opted-in to receiving the a
 goal asset send -a <asset-amount> --asset <asset-name> -f <asset-sender> -t <asset-receiver> --creator <asset-creator> -d data
 ```
 
+[See complete code...](#complete-code-example)
+
 **See also**
 
 - [Anatomy of an Asset Transfer Transaction](./transactions/index.md#transfer-an-asset)
@@ -786,6 +794,8 @@ Freezing or unfreezing an asset for an account requires a transaction that is si
 ``` goal tab="goal"  
 goal asset freeze --freezer <asset-freeze-account> --freeze=true --account <account-to-freeze> --creator <asset-creator> --asset <asset-name> -d data
 ```
+
+[See complete code...](#complete-code-example)
 
 **See also**
 
@@ -930,6 +940,8 @@ Revoking an asset for an account removes a specific number of the asset from the
 goal asset send -a <amount-to-revoke> --asset <asset-name> -f <address-of-revoke-target> -t <address-to-send-assets-to> --clawback <clawback-address> --creator <creator-address> -d data
 ```
 
+[See complete code...](#complete-code-example)
+
 **See also**
 
 - [Anatomy of an Asset Clawback Transaction](./transactions/index.md#revoke-an-asset)
@@ -1073,6 +1085,8 @@ Created assets can be destroyed only by the asset manager account. All of the as
 goal asset destroy --creator <creator-address> --manager <asset-manager-address> --asset <asset-name> -d data 
 ```
 
+[See complete code...](#complete-code-example)
+
 **See also**
 
 - [Anatomy of the Asset Destroy Transaction](./transactions/index.md#destroy-an-asset)
@@ -1120,6 +1134,8 @@ Reserve address:  <reserve-address>
 Freeze address:   <freeze-address>
 Clawback address: <clawback-address>
 ```
+
+# Complete Code Example
 
 ??? example "Complete Example - Asset Options"
     


### PR DESCRIPTION
# Summary
This is a proposed solution to this issue: https://github.com/algorand/docs/issues/100 and could be applied to this issue later too: https://github.com/algorand/docs/issues/57

# Problem
Some of the code snippets are better understood within the context of the full code example, which is located at the bottom of the page. We received feedback that people didn't even know about this full example.  

# Proposed Solution
Put a header above the full code example at the bottom of the page so that it shows up in the Table of Contents and becomes linkable. Then place a link to it underneath each code snippet.

# Alternatives Considered
There are a number of ways you could solve this problem. I've listed two below but you can imagine variations of these too. It's not clear which one is best. I chose the most subtle one with the assumption that it would at least help to solve the problem and we can always do something more drastic later if needed.

1. Place the link above the code snippet - Thought it was better for the user to see the focused code snippet first. Otherwise they could click the link, see the code for all the other examples, and not necessarily know where to look.
2. Place the full code example at the top of the page so users are anchored in knowing that there is a full code example behind each code snippet they see thereafter. The full code example was not optimized (with commenting for example) but the walkthrough was. Therefore, I think it is a better user experience to see the walkthrough first. A compromised variation of this could be to link to the full code example at the top so people are aware of it, without it taking over whole the page. We can always add this text now or later too.

# Testing
![completecode](https://user-images.githubusercontent.com/45209375/82610423-56127b80-9b8c-11ea-903f-23ec42761c63.png)
![CompleteCodeLink](https://user-images.githubusercontent.com/45209375/82610433-5c085c80-9b8c-11ea-8b27-3c5d52d6cbe8.png)
