### PR TITLE
Fix DevNet vs BetaNet + add link to network table

### DIFF
--- a/docs/run-a-node/operations/switch_networks.md
+++ b/docs/run-a-node/operations/switch_networks.md
@@ -1,10 +1,10 @@
 title: Switch Networks
-By default, an Algorand installation is configured to run on MainNet. For most users, this is the desired outcome. Developers, however, need access to TestNet or DevNet networks. This guide describes switching between networks.
+By default, an Algorand installation is configured to run on MainNet. For most users, this is the desired outcome. Developers, however, need access to [TestNet or BetaNet networks](../../../build-apps/setup/#choosing-a-network). This guide describes switching between networks.
 
 # Replacing the Genesis file
 Every Algorand node has a data directory that is used to store the ledger and other configuration information. As part of this configuration, a `genesis.json` file is used. The `genesis.json` file specifies the initial state of the blockchain - its ‘genesis block’. This is a JSON formatted file with the schema for the blockchain. It contains the network name and id, the protocol version and list of allocated addresses to start the chain with. Each address contains a list of things like address status and the amount of Algos owned by the address.
 
-As part of the installer, a `genesisfiles` directory is created under the node's installed location for binaries. This directory contains additional directories for each of the Algorand networks; DevNet, TestNet, and MainNet. These directories contain the `genesis.json` file for each of the Algorand networks (eg `~/node/genesisfiles/mainnet/genesis.json`). 
+As part of the installer, a `genesisfiles` directory is created under the node's installed location for binaries. This directory contains additional directories for each of the Algorand networks: BetaNet, TestNet, and MainNet. These directories contain the `genesis.json` file for each of the Algorand networks (eg `~/node/genesisfiles/mainnet/genesis.json`). 
 
 !!! info
     The genesis file for *Debian* and *RPM* installs are stored in the `/var/lib/algorand/genesis/` directory.


### PR DESCRIPTION
Most developers would want to use BetaNet rather than DevNet.