### PR TITLE
Update TestNet and MainNet to 2.0.7-stable

### DIFF
--- a/docs/reference/algorand-networks/mainnet.md
+++ b/docs/reference/algorand-networks/mainnet.md
@@ -1,10 +1,10 @@
 title: MainNet
 
 # Version
-`v2.0.6.stable`
+`v2.0.7.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.0.6-stable
+https://github.com/algorand/go-algorand/releases/tag/v2.0.7-stable
 
 # Genesis ID
 `mainnet-v1.0`

--- a/docs/reference/algorand-networks/testnet.md
+++ b/docs/reference/algorand-networks/testnet.md
@@ -1,10 +1,10 @@
 title: TestNet
 
 # Version
-`v2.0.6.stable`
+`v2.0.7.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.0.6-stable
+https://github.com/algorand/go-algorand/releases/tag/v2.0.7-stable
 
 # Genesis ID
 `testnet-v1.0`


### PR DESCRIPTION
Algorand is updating this morning to 2.0.7-stable, so updating docs to reflect this.