### PR TITLE
Update BetaNet current version to 2.0.15

### DIFF
--- a/docs/reference/algorand-networks/betanet.md
+++ b/docs/reference/algorand-networks/betanet.md
@@ -14,10 +14,10 @@ title: BetaNet 🔷
 🔷 = BetaNet availability only
 
 # Version
-`v2.0.14.beta`
+`v2.0.15.beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.0.14-beta
+https://github.com/algorand/go-algorand/releases/tag/v2.0.15-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
BetaNet is scheduled to update to 2.0.15 on 6/25/2020 at 9:30am.