### PR TITLE
Update TestNet/MainNet to 2.0.8-stable

### DIFF
--- a/docs/reference/algorand-networks/mainnet.md
+++ b/docs/reference/algorand-networks/mainnet.md
@@ -12,10 +12,10 @@ title: MainNet
 - [Indexer REST API](../rest-apis/indexer.md)
   
 # Version
-`v2.0.7.stable`
+`v2.0.8.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.0.7-stable
+https://github.com/algorand/go-algorand/releases/tag/v2.0.8-stable
 
 # Genesis ID
 `mainnet-v1.0`

--- a/docs/reference/algorand-networks/testnet.md
+++ b/docs/reference/algorand-networks/testnet.md
@@ -12,10 +12,10 @@ title: TestNet
 - [Indexer REST API](../rest-apis/indexer.md)
   
 # Version
-`v2.0.7.stable`
+`v2.0.8.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.0.7-stable
+https://github.com/algorand/go-algorand/releases/tag/v2.0.8-stable
 
 # Genesis ID
 `testnet-v1.0`


### PR DESCRIPTION
Update documentation to point TestNet/MainNet to 2.0.8-stable. Effective 9/26/2020 at 10:30am EDT.
