### PR TITLE
Update betanet.md to 2.1.1-beta

### DIFF
--- a/docs/reference/algorand-networks/betanet.md
+++ b/docs/reference/algorand-networks/betanet.md
@@ -12,10 +12,10 @@ Visit the new docs to get started:
 🔷 = BetaNet availability only
 
 # Version
-`v2.1.0.beta`
+`v2.1.1.beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.1.0-beta
+https://github.com/algorand/go-algorand/releases/tag/v2.1.1-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
BetaNet will go live with 2.1.1 at 11:30am 8/7.