### PR TITLE
Update BetaNet to 2.1.3-beta

### DIFF
--- a/docs/reference/algorand-networks/betanet.md
+++ b/docs/reference/algorand-networks/betanet.md
@@ -12,10 +12,10 @@ Visit the new docs to get started:
 🔷 = BetaNet availability only
 
 # Version
-`v2.1.1.beta`
+`v2.1.3.beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.1.1-beta
+https://github.com/algorand/go-algorand/releases/tag/v2.1.3-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
BetaNet was updated to 2.1.3-beta on 8/17 at 9:30pm EDT.