### PR TITLE
2.1.3-stable MainNet/TestNet Update

### DIFF
--- a/docs/reference/algorand-networks/mainnet.md
+++ b/docs/reference/algorand-networks/mainnet.md
@@ -12,10 +12,10 @@ title: MainNet
 - [Indexer REST API](../rest-apis/indexer.md)
   
 # Version
-`v2.0.9.stable`
+`v2.1.3.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.0.9-stable
+https://github.com/algorand/go-algorand/releases/tag/v2.1.3-stable
 
 # Genesis ID
 `mainnet-v1.0`

--- a/docs/reference/algorand-networks/testnet.md
+++ b/docs/reference/algorand-networks/testnet.md
@@ -12,10 +12,10 @@ title: TestNet
 - [Indexer REST API](../rest-apis/indexer.md)
   
 # Version
-`v2.0.9.stable`
+`v2.1.3.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.0.9-stable
+https://github.com/algorand/go-algorand/releases/tag/v2.1.3-stable
 
 # Genesis ID
 `testnet-v1.0`


### PR DESCRIPTION
Update MainNet and TestNet documentation to 2.1.3-stable. This is scheduled to go live Wednesday 8/19/2020 at 10:30am.