### PR TITLE
Update BetaNet to 2.1.4-beta

### DIFF
--- a/docs/reference/algorand-networks/betanet.md
+++ b/docs/reference/algorand-networks/betanet.md
@@ -12,10 +12,10 @@ Visit the new docs to get started:
 🔷 = BetaNet availability only
 
 # Version
-`v2.1.3.beta`
+`v2.1.4.beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.1.3-beta
+https://github.com/algorand/go-algorand/releases/tag/v2.1.4-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
2.1.4-beta was deployed to BetaNet on 8/26.