### PR TITLE
Update TestNet and MainNet to v2.1.4-stable

### DIFF
--- a/docs/reference/algorand-networks/mainnet.md
+++ b/docs/reference/algorand-networks/mainnet.md
@@ -7,10 +7,10 @@ title: MainNet
 - [Fast Catchup](../../../run-a-node/setup/install/#sync-node-network-using-fast-catchup)
   
 # Version
-`v2.1.3.stable`
+`v2.1.4.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.1.3-stable
+https://github.com/algorand/go-algorand/releases/tag/v2.1.4-stable
 
 # Genesis ID
 `mainnet-v1.0`

--- a/docs/reference/algorand-networks/testnet.md
+++ b/docs/reference/algorand-networks/testnet.md
@@ -7,10 +7,10 @@ title: TestNet
 - [Fast Catchup](../../../run-a-node/setup/install/#sync-node-network-using-fast-catchup)
   
 # Version
-`v2.1.3.stable`
+`v2.1.4.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.1.3-stable
+https://github.com/algorand/go-algorand/releases/tag/v2.1.4-stable
 
 # Genesis ID
 `testnet-v1.0`


### PR DESCRIPTION
As of 8/31/2020, the officially supported version is 2.1.4-stable.