### PR TITLE
package versions are pinned

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-mkdocs
-mkdocs-material
-mkdocs-awesome-pages-plugin
-pymdown-extensions
+mkdocs==1.1
+mkdocs-material==4.6.3
+mkdocs-awesome-pages-plugin==2.2.1
+pymdown-extensions==6.3
 
 


### PR DESCRIPTION
Related Ticket: https://hipo.codebasehq.com/projects/algorand-developer-portal/tickets/320

We should add a fixed version for every package that is in the requirements file to prevent any conflicts with the backend side.
Also, this pull request aims to remove warning about `PymdownxDeprecationWarning` during the building.