### PR TITLE
Update to 2.1.5-stable

### DIFF
--- a/docs/reference/algorand-networks/mainnet.md
+++ b/docs/reference/algorand-networks/mainnet.md
@@ -7,10 +7,10 @@ title: MainNet
 - [Fast Catchup](../../../run-a-node/setup/install/#sync-node-network-using-fast-catchup)
   
 # Version
-`v2.1.4.stable`
+`v2.1.5.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.1.4-stable
+https://github.com/algorand/go-algorand/releases/tag/v2.1.5-stable
 
 # Genesis ID
 `mainnet-v1.0`

--- a/docs/reference/algorand-networks/testnet.md
+++ b/docs/reference/algorand-networks/testnet.md
@@ -7,10 +7,10 @@ title: TestNet
 - [Fast Catchup](../../../run-a-node/setup/install/#sync-node-network-using-fast-catchup)
   
 # Version
-`v2.1.4.stable`
+`v2.1.5.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.1.4-stable
+https://github.com/algorand/go-algorand/releases/tag/v2.1.5-stable
 
 # Genesis ID
 `testnet-v1.0`


### PR DESCRIPTION
Update testnet and mainnet to 2.1.5-stable. This is currently live.