### PR TITLE
Update betanet.md to 2.1.6-beta

### DIFF
--- a/docs/reference/algorand-networks/betanet.md
+++ b/docs/reference/algorand-networks/betanet.md
@@ -12,10 +12,10 @@ Visit the new docs to get started:
 🔷 = BetaNet availability only
 
 # Version
-`v2.1.5.beta`
+`v2.1.6.beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.1.5-beta
+https://github.com/algorand/go-algorand/releases/tag/v2.1.6-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
This change is live as of 8:30pm EDT 9/24.