### PR TITLE
Update mainnet and testnet to v2.2.0-stable

### DIFF
--- a/docs/reference/algorand-networks/mainnet.md
+++ b/docs/reference/algorand-networks/mainnet.md
@@ -7,10 +7,10 @@ title: MainNet
 - [Fast Catchup](../../../run-a-node/setup/install/#sync-node-network-using-fast-catchup)
   
 # Version
-`v2.1.6.stable`
+`v2.2.0.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.1.6-stable
+https://github.com/algorand/go-algorand/releases/tag/v2.2.0-stable
 
 # Genesis ID
 `mainnet-v1.0`


### PR DESCRIPTION
This is scheduled to go live at 10:30am today (11/4).