### PR TITLE
Update betanet to 2.4.0-beta

### DIFF
--- a/docs/reference/algorand-networks/betanet.md
+++ b/docs/reference/algorand-networks/betanet.md
@@ -12,10 +12,10 @@ Visit the new docs to get started:
 🔷 = BetaNet availability only
 
 # Version
-`v2.3.0-beta`
+`v2.4.0-beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.3.0-beta
+https://github.com/algorand/go-algorand/releases/tag/v2.4.0-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
Effective as of today 1/19 at 10:30am.