### PR TITLE
Adding Python one-liners for addr/pk conversion

### DIFF
--- a/docs/features/accounts/index.md
+++ b/docs/features/accounts/index.md
@@ -23,6 +23,14 @@ The **public key** is transformed into an Algorand address, by adding a 4-byte c
 
 !!! info
 	Since users almost never see the true public key, and the Algorand address is a unique mapping back to the public key, the use of the term **public key** is frequently (and inaccurately) used to mean **address**. 
+	
+!!! tip
+	Assuming the [Python SDK is installed](../../reference/sdks/#installation_1), it is possible to convert addresses to (base32-encoded) public keys and vice-versa using the following one-liners (here used on the address `VCMJKWOY5P5P7SKMZFFOCEROPJCZOTIJMNIYNUCKH7LRO45JMJP6UYBIJA`):
+	```bash
+	python3 -c "import base64, sys, algosdk; [print(base64.b32encode(algosdk.encoding.decode_address(line.strip())).decode()) for line in sys.stdin if line.strip()]" <<< VCMJKWOY5P5P7SKMZFFOCEROPJCZOTIJMNIYNUCKH7LRO45JMJP6UYBIJA
+
+	python3 -c "import base64, sys, algosdk; [print(algosdk.encoding.encode_address(base64.b32decode(line.strip()))) for line in sys.stdin if line.strip()]" <<< VCMJKWOY5P5P7SKMZFFOCEROPJCZOTIJMNIYNUCKH7LRO45JMJPQ====
+	```
 
 ### Transformation: Private Key to base64 private key
 


### PR DESCRIPTION
In many situations (e.g., when using `msgpacktool -d -b32`), base32-encoded public keys are displayed instead of addresses with checksum.
I've added one-liners to the documentation to allow people to easily convert them back and forth.
This may be the wrong place to write those though.