### PR TITLE
Fix json.dump for suggested params in Python

### DIFF
--- a/docs/build-apps/connect.md
+++ b/docs/build-apps/connect.md
@@ -218,7 +218,7 @@ The _/v2/transactions/params_ endpoint returns information about the identity of
 ...
 	try:
 		params = algod_client.suggested_params()
-		print(json.dumps(params, indent=4))
+		print(json.dumps(vars(params), indent=4))
 	except Exception as e:
 		print(e)
 ...


### PR DESCRIPTION
With the current version of the SDK, `json.dumps(params)` raises the following exception `TypeError: Object of type SuggestedParams is not JSON serializable`.
This is because `param` is an object not a dict.

This issue was found by "user" on Discord.