### PR TITLE
Maybe fix list display on dev site

### DIFF
--- a/docs/reference/rest-apis/algod/v2.md
+++ b/docs/reference/rest-apis/algod/v2.md
@@ -846,6 +846,7 @@ GET /v2/transactions/pending/{txid}
 
 **Description**
 Given a transaction id of a recently submitted transaction, it returns information about it.  There are several cases when this might succeed:
+
 * transaction committed (committed round > 0)
 * transaction still in the pool (committed round = 0, pool error = "")
 * transaction removed from pool due to error (committed round = 0, pool error != "")

--- a/docs/reference/rest-apis/algod/v2.md
+++ b/docs/reference/rest-apis/algod/v2.md
@@ -846,9 +846,9 @@ GET /v2/transactions/pending/{txid}
 
 **Description**
 Given a transaction id of a recently submitted transaction, it returns information about it.  There are several cases when this might succeed:
-- transaction committed (committed round > 0)
-- transaction still in the pool (committed round = 0, pool error = "")
-- transaction removed from pool due to error (committed round = 0, pool error != "")
+* transaction committed (committed round > 0)
+* transaction still in the pool (committed round = 0, pool error = "")
+* transaction removed from pool due to error (committed round = 0, pool error != "")
 Or the transaction may have happened sufficiently long ago that the node no longer remembers it, and this will return an error.
 
 


### PR DESCRIPTION
the - seems to not be rendered correctly on the developer.algorand.org site, the lists that are displayed correctly have an asterisk rather than a -.  I did not check to see if this appeared anywhere else