### PR TITLE
Add flag to base64

### DIFF
--- a/docs/features/asc1/stateless/walkthrough.md
+++ b/docs/features/asc1/stateless/walkthrough.md
@@ -133,10 +133,10 @@ LogicSig: {
 }
 ```
 # Passing Parameters to TEAL with Goal
-Parameters can be passed to a TEAL program using `goal`. The parameters must be passed as base64 encoded strings. For example, to pass “mystringargument” to a stateless TEAL program, the argument can be encoded using an `echo` command with base64.
+Parameters can be passed to a TEAL program using `goal`. The parameters must be passed as base64 encoded strings. For example, to pass “mystringargument” to a stateless TEAL program, the argument can be encoded using an `echo` command with base64. The `-w0` argument disabled wrapping that defaults to 76 characters. 
 
 ```
-$ echo -n mystringargument | base64
+$ echo -n mystringargument | base64 -w0
 bXlzdHJpbmdhcmd1bWVudA==
 ```
 

--- a/docs/features/asc1/stateless/walkthrough.md
+++ b/docs/features/asc1/stateless/walkthrough.md
@@ -133,7 +133,7 @@ LogicSig: {
 }
 ```
 # Passing Parameters to TEAL with Goal
-Parameters can be passed to a TEAL program using `goal`. The parameters must be passed as base64 encoded strings. For example, to pass “mystringargument” to a stateless TEAL program, the argument can be encoded using an `echo` command with base64. The `-w0` argument disabled wrapping that defaults to 76 characters. 
+Parameters can be passed to a TEAL program using `goal`. The parameters must be passed as base64 encoded strings. For example, to pass “mystringargument” to a stateless TEAL program, the argument can be encoded using an `echo` command with base64. The `-w0` argument disables wrapping that defaults to 76 characters. 
 
 ```
 $ echo -n mystringargument | base64 -w0


### PR DESCRIPTION
The base64 program adds a newline after 76 characters for legacy reasons and is not needed for this application.