### PR TITLE
Atomic transfers: Fix typo in grouping transactions with `goal`

### DIFF
--- a/docs/features/atomic_transfers.md
+++ b/docs/features/atomic_transfers.md
@@ -165,7 +165,7 @@ tx2.Group = gid
 ```
 
 ``` goal tab="goal"
-$ goal clerk group -i yourwalletcombinedtransactions.tx -o groupedtransactions.tx -d data -w 
+$ goal clerk group -i combinedtransactions.tx -o groupedtransactions.tx -d data -w yourwallet
 ```
 
 ## Split Transactions


### PR DESCRIPTION
Hi Algorand team! Just a small typo I noticed while trying atomic transfers.