### PR TITLE
Update networks to 2.5.4

### DIFF
--- a/docs/reference/algorand-networks/betanet.md
+++ b/docs/reference/algorand-networks/betanet.md
@@ -12,10 +12,10 @@ Visit the new docs to get started:
 🔷 = BetaNet availability only
 
 # Version
-`v2.5.2-beta`
+`v2.5.4-beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.5.2-beta
+https://github.com/algorand/go-algorand/releases/tag/v2.5.4-beta
 
 # Genesis ID
 `betanet-v1.0`

--- a/docs/reference/algorand-networks/mainnet.md
+++ b/docs/reference/algorand-networks/mainnet.md
@@ -7,10 +7,10 @@ title: MainNet
 - [Fast Catchup](../../../run-a-node/setup/install/#sync-node-network-using-fast-catchup)
   
 # Version
-`v2.4.1.stable`
+`v2.5.4.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.4.1-stable
+https://github.com/algorand/go-algorand/releases/tag/v2.5.4-stable
 
 # Genesis ID
 `mainnet-v1.0`

--- a/docs/reference/algorand-networks/testnet.md
+++ b/docs/reference/algorand-networks/testnet.md
@@ -7,10 +7,10 @@ title: TestNet
 - [Fast Catchup](../../../run-a-node/setup/install/#sync-node-network-using-fast-catchup)
   
 # Version
-`v2.4.1.stable`
+`v2.5.4.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.4.1-stable
+https://github.com/algorand/go-algorand/releases/tag/v2.5.4-stable
 
 # Genesis ID
 `testnet-v1.0`


### PR DESCRIPTION
Update BetaNet to 2.5.4-beta, and MainNet/TestNet to 2.5.4-stable. This is to go live after 4/13 10:30am.