### PR TITLE
Update install.md

### DIFF
--- a/docs/run-a-node/setup/install.md
+++ b/docs/run-a-node/setup/install.md
@@ -90,7 +90,7 @@ sudo apt-get update
 sudo apt-get install -y gnupg2 curl software-properties-common
 curl -O https://releases.algorand.com/key.pub
 sudo apt-key add key.pub
-sudo add-apt-repository "deb https://releases.algorand.com/deb/ stable main"
+sudo add-apt-repository "deb [arch=amd64] https://releases.algorand.com/deb/ stable main"
 sudo apt-get update
 
 # To get both algorand and the devtools:


### PR DESCRIPTION
Fixes installation error:
> N: Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'https://releases.algorand.com/deb stable InRelease' doesn't support architecture 'i386'

when installing on a 64-bit machine that has i386 support on Ubuntu 20.04 LTS (which can be found by):
> $ dpkg --print-foreign-architectures
> i386
> $ dpkg --print-architecture
> amd64