### PR TITLE
improve readability on stateless contract beginner examples, fix to b…

### DIFF
--- a/docs/features/asc1/stateless/sdks.md
+++ b/docs/features/asc1/stateless/sdks.md
@@ -262,12 +262,18 @@ The SDKs require that parameters to a stateless smart contract TEAL program be i
     The samples show setting parameters at the creation of the logic signature. These parameters can be changed at the time of submitting the transaction.
 
 ```javascript tab="JavaScript"
-    //string parameter
-    let args = ["my string"];
-    let lsig = algosdk.makeLogicSig(program, args);
-    //integer parameter
-    let args = [[123]];
-    let lsig = algosdk.makeLogicSig(program, args);
+    // string parameter
+    const args = ["my string"];
+    const lsig = algosdk.makeLogicSig(program, args);
+    
+    // integer parameter
+    const value = 123;
+    const buffer = Buffer.alloc(8);
+    const bigIntValue = BigInt(value);
+    buffer.writeBigUInt64BE(bigIntValue)
+    const arg1 = Uint8Array.from(buffer);
+    const args = [arg1];
+    const lsig = algosdk.makeLogicSig(program, args);
 ```
 
 ```python tab="Python"

--- a/docs/features/asc1/stateless/sdks.md
+++ b/docs/features/asc1/stateless/sdks.md
@@ -262,13 +262,13 @@ The SDKs require that parameters to a stateless smart contract TEAL program be i
 
 ```javascript tab="JavaScript"
     // string parameter
-    const args = ["my string"];
+    const args = [];
+    args.push([...Buffer.from("my string")]);
     const lsig = algosdk.makeLogicSig(program, args);
     
     // integer parameter
-    const value = 123;
-    const arg1 = algosdk.encodeUint64(value)
-    const args = [arg1];
+    const args = [];
+    args.push(algosdk.encodeUint64(123));
     const lsig = algosdk.makeLogicSig(program, args);
 ```
 
@@ -402,14 +402,15 @@ const main = async () => {
     // Use this if no args
     // const lsig = algosdk.makeLogicSig(program);
 
+    // Initialize arguments array
+    const args = [];
+
     // String parameter
-    // const args = ["my string"];
-    // const lsig = algosdk.makeLogicSig(program, args);
+    // args.push([...Buffer.from("my string")]);
 
     // Integer parameter
-    const value = 123;
-    const arg1 = algosdk.encodeUint64(value)
-    const args = [arg1];
+    args.push(algosdk.encodeUint64(123));
+
 
     const lsig = algosdk.makeLogicSig(program, args);
     console.log("lsig : " + lsig.address());   
@@ -804,11 +805,9 @@ const main = async () => {
     const  results = await algodClient.compile(data).do();
     const program = new Uint8Array(Buffer.from(results.result, "base64"));
 
-    // Integer parameter
-    const value = 123;
-    const arg1 = algosdk.encodeUint64(value)
-    const args = [arg1];
-
+    const args = [];
+    args.push(algosdk.encodeUint64(123));
+   
     const lsig = algosdk.makeLogicSig(program, args); 
     
     // *** Begin account delegation changes ***

--- a/docs/features/asc1/stateless/sdks.md
+++ b/docs/features/asc1/stateless/sdks.md
@@ -1212,6 +1212,8 @@ func main() {
     }
 ```
 
+!!! Notice
+    The samplearg.teal file will compile to the address UVBYHRZIHUNUELDO6HWUAHOZF6G66W6T3JOXIIUSV3LDSBWVCFZ6LM6NCA, please fund this address with at least 11000 microALGO else executing the sample code as written will result in an overspend response from the network node.
 
 !!! info
     The example code snippets are provided throughout this page and are abbreviated for conciseness and clarity. Full running code examples for each SDK are available within the GitHub repo for V1 and V2 at [/examples/smart_contracts](https://github.com/algorand/docs/tree/master/examples/smart_contracts) and for [download](https://github.com/algorand/docs/blob/master/examples/smart_contracts/smart_contracts.zip?raw=true) (.zip).

--- a/docs/features/asc1/stateless/sdks.md
+++ b/docs/features/asc1/stateless/sdks.md
@@ -63,7 +63,7 @@ const main = async () => {
     const data = fs.readFileSync(filePath);
 
     // Compile teal
-    const results = await algodClient.compile('x').do();
+    const results = await algodClient.compile(data).do();
     return results;
 };
 
@@ -223,7 +223,6 @@ ASABACI=
 The response result from the TEAL `compile` command above is used to create the `program` variable. This variable can then be used as an input parameter to the function to make a logic signature.
 
 ```javascript tab="JavaScript"
-    // let program = new Uint8Array(Buffer.from("ASABACI=", "base64"));
     const program = new Uint8Array(Buffer.from(results.result , "base64"));
     const lsig = algosdk.makeLogicSig(program);   
 ```
@@ -268,10 +267,7 @@ The SDKs require that parameters to a stateless smart contract TEAL program be i
     
     // integer parameter
     const value = 123;
-    const buffer = Buffer.alloc(8);
-    const bigIntValue = BigInt(value);
-    buffer.writeBigUInt64BE(bigIntValue)
-    const arg1 = Uint8Array.from(buffer);
+    const arg1 = algosdk.encodeUint64(value)
     const args = [arg1];
     const lsig = algosdk.makeLogicSig(program, args);
 ```
@@ -412,10 +408,7 @@ const main = async () => {
 
     // Integer parameter
     const value = 123;
-    const buffer = Buffer.alloc(8);
-    const bigIntValue = BigInt(value);
-    buffer.writeBigUInt64BE(bigIntValue)
-    const arg1 = Uint8Array.from(buffer);
+    const arg1 = algosdk.encodeUint64(value)
     const args = [arg1];
 
     const lsig = algosdk.makeLogicSig(program, args);
@@ -813,10 +806,7 @@ const main = async () => {
 
     // Integer parameter
     const value = 123;
-    const buffer = Buffer.alloc(8);
-    const bigIntValue = BigInt(value);
-    buffer.writeBigUInt64BE(bigIntValue)
-    const arg1 = Uint8Array.from(buffer);
+    const arg1 = algosdk.encodeUint64(value)
     const args = [arg1];
 
     const lsig = algosdk.makeLogicSig(program, args); 


### PR DESCRIPTION
**Is your addition related to a problem? Please describe.**
In many places in the docs `let` or `var` are used instead of `const`. In this particular area of the code, I've changed `var` and `let` to `const` where applicable. I also re-organized imports to be consistent with node/js best practices. Lastly I went with a `main` function running with a promise at the bottom. I saw this in other docs and I thought it looked very clear and clean.

**Describe alternatives you've considered**
I considered with the account delegation signing to just show the difference in code from the code example above or putting the full example in there again. In the end I went with just the main function with a note in the comments and all other non-relevant and redundant comments removed.
