### PR TITLE
Add vim TEAL plugin

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -69,6 +69,7 @@ If you have a project you want featured on the community site, [reach out](mailt
 |------|------|
 | <center>[Algorand Wallet Manager](https://github.com/CiottiGiorgio/Algorand-Wallet-Manager)</center> | This Python application is a graphic interface for the user who owns or have access to an Algorand node and would like to issue operations through a GUI rather than CLI. (i.e.: manage wallets and addresses, send transactions, save a contact list) |
 | <center>[Sandbox](https://github.com/algorand/sandbox)</center> | Algorand Sandbox. |
+| <center>[vim TEAL plugin](https://github.com/aldur/vim-algorand-teal)</center> | Syntax highlighting for TEAL scripts within vim. |
 
 # Smart Contract Utilities and Libraries
 


### PR DESCRIPTION
This PR adds a link to a minimalistic vim TEAL plugin that adds syntax highlighting to TEAL v3 scripts.