### PR TITLE
Add JS SDK Updates and Various Other Docs Updates for Versioning and Cleanup

### DIFF
--- a/docs/features/asa.md
+++ b/docs/features/asa.md
@@ -315,7 +315,7 @@ goal asset create --creator <address> --total 1000 --unitname <unit-name> --asse
 
 **Authorized by**: [Asset Manager Account](../reference/transactions.md#manageraddr)
 
-After an asset has been created only the manager, reserve, freeze and reserve accounts can be changed. All other parameters are locked for the life of the asset. If any of these addresses are set to `""` that address will be cleared and can never be reset for the life of the asset. Only the manager account can make configuration changes and must authorize the transaction.
+After an asset has been created only the manager, reserve, freeze and clawback accounts can be changed. All other parameters are locked for the life of the asset. If any of these addresses are set to `""` that address will be cleared and can never be reset for the life of the asset. Only the manager account can make configuration changes and must authorize the transaction.
 
 ``` javascript tab="JavaScript"
 // Asset configuration specific parameters

--- a/docs/reference/algorand-networks/betanet.md
+++ b/docs/reference/algorand-networks/betanet.md
@@ -12,10 +12,10 @@ Visit the new docs to get started:
 🔷 = BetaNet availability only
 
 # Version
-`v2.5.5-beta`
+`v2.5.6-beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.5.5-beta
+https://github.com/algorand/go-algorand/releases/tag/v2.5.6-beta
 
 # Genesis ID
 `betanet-v1.0`

--- a/docs/reference/payment_prompts.md
+++ b/docs/reference/payment_prompts.md
@@ -1,4 +1,4 @@
-title: Payment Prompts
+title: URI Scheme
 
 This URI specification represents a standardized way for applications and websites to send requests and information through deeplinks, QR codes, etc. It is heavily based on Bitcoin’s [BIP-0021](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki) and should be seen as derivative of it. The decision to base it on BIP-0021 was made to make it easy and compatible as possible for any other application.
 

--- a/docs/reference/sdks/index.md
+++ b/docs/reference/sdks/index.md
@@ -78,7 +78,7 @@ In the above example, the block information will be displayed if the block exist
 
 # JavaScript
 ## Installation
-The JavaScript SDK is available as an [NPM package](https://www.npmjs.com/package/algosdk) or as a [minified JavaScript library](https://github.com/algorand/js-algorand-sdk/blob/master/dist/algosdk.min.js). 
+The JavaScript SDK is available as an [NPM package](https://www.npmjs.com/package/algosdk) or as a [minified JavaScript library](https://unpkg.com/algosdk@latest).
 
 Requirements: [Node.js](https://nodejs.org/en/download/) 
 
@@ -86,14 +86,14 @@ Requirements: [Node.js](https://nodejs.org/en/download/)
 $ npm install algosdk
 ```
 
-To install the minified library, download the [latest distribution](https://github.com/algorand/js-algorand-sdk/tree/develop/dist) and add it to the project's library location. Use the src tag to specify the location of the library.
+To use the minified library hosted on the [unpkg CDN](https://unpkg.com/), include the browser bundle directly in your HTML like so:
 
 ```javascript tab="JavaScript"
-<script src="algosdk.min.js"/> 
+<script src="https://unpkg.com/algosdk@latest" />
+<!-- or https://cdn.jsdelivr.net/npm/algosdk@latest -->
 ```
 
-The [GitHub repository](https://github.com/algorand/js-algorand-sdk) contains additional documentation and examples.
-
+Additional documentation is available on the JavaScript SDK [reference documentation site](https://algorand.github.io/js-algorand-sdk/), and examples can be found in the [GitHub repository](https://github.com/algorand/js-algorand-sdk).
 
 # Python
 ## Installation

--- a/docs/run-a-node/setup/install.md
+++ b/docs/run-a-node/setup/install.md
@@ -90,7 +90,7 @@ sudo apt-get update
 sudo apt-get install -y gnupg2 curl software-properties-common
 curl -O https://releases.algorand.com/key.pub
 sudo apt-key add key.pub
-sudo add-apt-repository "deb https://releases.algorand.com/deb/ stable main"
+sudo add-apt-repository "deb [arch=amd64] https://releases.algorand.com/deb/ stable main"
 sudo apt-get update
 
 # To get both algorand and the devtools:


### PR DESCRIPTION
This PR updates a number of unrelated docs to update version numbers and cleanup wording. The JavaScript SDK documentation is now references the new source repo.