### PR TITLE
Update broken phonebook link in relay node page

### DIFF
--- a/docs/reference/node/relay.md
+++ b/docs/reference/node/relay.md
@@ -30,7 +30,7 @@ The node can also be set up to connect to multiple relays using a `;` separated 
 ```
 
 !!! warning
-	Using the above process will prevent the node from connecting to any of the Algorand networks. See the [Phonebook](../../../reference-docs/node_files/#phonebookjson) documentation for more information on how nodes connect to relays.
+	Using the above process will prevent the node from connecting to any of the Algorand networks. See the [Phonebook](./artifacts.md#phonebookjson) documentation for more information on how nodes connect to relays.
 
 
 


### PR DESCRIPTION
There is a broken link for "Phonebook" at the bottom of https://developer.algorand.org/docs/reference/node/relay/ that I noticed and I believe this will fix it (tested it with `mkdocs serve`).