### PR TITLE
Python SDK under construct the transaction in "3.Your First Transaction" page missing PaymentTxn import

### DIFF
--- a/docs/build-apps/hello_world.md
+++ b/docs/build-apps/hello_world.md
@@ -233,6 +233,8 @@ let txn = algosdk.makePaymentTxnWithSuggestedParams(myAccount.addr, receiver, 10
 ```
 
 ```python tab="Python"
+from algosdk.future.transaction import PaymentTxn
+
 params = algod_client.suggested_params()
 # comment out the next two (2) lines to use suggested fees
 params.flat_fee = True

--- a/docs/build-apps/hello_world.md
+++ b/docs/build-apps/hello_world.md
@@ -490,7 +490,7 @@ def wait_for_confirmation(client, transaction_id, timeout):
 ```java tab="Java"
 /**
  * utility function to wait on a transaction to be confirmed
- * the timeout parameter indicates how many rounds do you wish to check pending transactions for
+ * the timeout parameter indicates how many rounds do you wish to check pending transactions for [fix]
  */
 public PendingTransactionResponse waitForConfirmation(AlgodClient myclient, String txID, Integer timeout)
 throws Exception {

--- a/docs/build-apps/hello_world.md
+++ b/docs/build-apps/hello_world.md
@@ -490,7 +490,7 @@ def wait_for_confirmation(client, transaction_id, timeout):
 ```java tab="Java"
 /**
  * utility function to wait on a transaction to be confirmed
- * the timeout parameter indicates how many rounds do you wish to check pending transactions for [fix]
+ * the timeout parameter indicates how many rounds do you wish to check pending transactions for
  */
 public PendingTransactionResponse waitForConfirmation(AlgodClient myclient, String txID, Integer timeout)
 throws Exception {


### PR DESCRIPTION
https://developer.algorand.org/docs/build-apps/hello_world/

the python SDK example for "construct the transaction" section did not import PaymentTxn from algosdk.future.transaction so PaymentTxn was undefined.

Changes I made:

- added an import of PaymentTxn from algosdk.future.transaction on the docs/build-apps/hello_world.md file at line 236.
