### PR TITLE
Update to 2.7.1 beta

### DIFF
--- a/docs/reference/algorand-networks/betanet.md
+++ b/docs/reference/algorand-networks/betanet.md
@@ -12,10 +12,10 @@ Visit the new docs to get started:
 🔷 = BetaNet availability only
 
 # Version
-`v2.7.0-beta`
+`v2.7.1-beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.7.0-beta
+https://github.com/algorand/go-algorand/releases/tag/v2.7.1-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
BetaNet was upgraded to version 2.7.1 today, Tuesday Jun 22, 2021 8:30AM ET (12:30PM UTC).