### PR TITLE
Mentioning opt-out in the AssetCloseTo field

### DIFF
--- a/docs/reference/transactions.md
+++ b/docs/reference/transactions.md
@@ -85,7 +85,7 @@ Includes all fields in [Header](#common-fields-header-and-type) and `"type"` is 
 |<a name="assetamount">AssetAmount</a>|_required_|uint64|`"aamt"`| The amount of the asset to be transferred. A zero amount transferred to self allocates that asset in the account's Asset map.|
 |<a name="assetsender">AssetSender</a>|_required_|Address|`"asnd"`|The sender of the transfer. The regular [sender](#sender) field should be used and this one set to the zero value for regular transfers between accounts. If this value is nonzero, it indicates a clawback transaction where the [sender](#sender) is the asset's clawback address and the asset sender is the address from which the funds will be withdrawn.|
 |<a name="assetreceiver">AssetReceiver</a>|_required_|Address|`"arcv"`| The recipient of the asset transfer.|
-|<a name="assetcloseto">AssetCloseTo</a>|_optional_|Address|`"aclose"`|Specify this field to remove the asset holding from the [sender](#sender) account and reduce the account's minimum balance. |
+|<a name="assetcloseto">AssetCloseTo</a>|_optional_|Address|`"aclose"`|Specify this field to remove the asset holding from the [sender](#sender) account and reduce the account's minimum balance (i.e. opt-out of the asset). |
 
 # Asset Accept Transaction 
 Transaction Object Type: `AssetTransferTx`


### PR DESCRIPTION
I've seen a few questions come into the discord about how to opt out of an asset.  This should help when searching the docs with the keywords `opt-out`.