### PR TITLE
go-algorand @2.7.1 | indexer @2.5.0

### DIFF
--- a/docs/reference/cli/goal/app/create.md
+++ b/docs/reference/cli/goal/app/create.md
@@ -36,6 +36,8 @@ goal app create [flags]
 
       --dryrun-dump-format string   Dryrun dump format: json, msgp (default "json")
 
+      --extra-pages uint32          Additional program space for supporting larger TEAL assembly program. A maximum of 3 extra pages is allowed. A page is 1024 bytes.
+
       --fee uint                    The transaction fee (automatically determined by default), in microAlgos
 
       --firstvalid uint             The first round where the transaction may be committed to the ledger

--- a/docs/reference/rest-apis/algod/v2.md
+++ b/docs/reference/rest-apis/algod/v2.md
@@ -889,10 +889,9 @@ GET /v2/transactions/pending/{txid}
 
 **Description**
 Given a transaction id of a recently submitted transaction, it returns information about it.  There are several cases when this might succeed:
-
-* transaction committed (committed round > 0)
-* transaction still in the pool (committed round = 0, pool error = "")
-* transaction removed from pool due to error (committed round = 0, pool error != "")
+- transaction committed (committed round > 0)
+- transaction still in the pool (committed round = 0, pool error = "")
+- transaction removed from pool due to error (committed round = 0, pool error != "")
 Or the transaction may have happened sufficiently long ago that the node no longer remembers it, and this will return an error.
 
 
@@ -982,6 +981,7 @@ data/basics/userBalance.go : AccountData
 |**amount**  <br>*required*|\[algo\] total number of MicroAlgos in the account|integer|
 |**amount-without-pending-rewards**  <br>*required*|specifies the amount of MicroAlgos in the account, without the pending rewards.|integer|
 |**apps-local-state**  <br>*optional*|\[appl\] applications local data stored in this account.<br><br>Note the raw object uses `map[int] -> AppLocalState` for this type.|< [ApplicationLocalState](#applicationlocalstate) > array|
+|**apps-total-extra-pages**  <br>*optional*|\[teap\] the sum of all extra application program pages for this account.|integer|
 |**apps-total-schema**  <br>*optional*|\[tsch\] stores the sum of all of the local schemas and global schemas in this account.<br><br>Note: the raw account uses `StateSchema` for this type.|[ApplicationStateSchema](#applicationstateschema)|
 |**assets**  <br>*optional*|\[asset\] assets held by this account.<br><br>Note the raw object uses `map[int] -> AssetHolding` for this type.|< [AssetHolding](#assetholding) > array|
 |**auth-addr**  <br>*optional*|\[spend\] the address against which signing should be checked. If empty, the address of the current account is used. This field can be updated in any transaction by setting the RekeyTo field.|string|
@@ -1054,6 +1054,7 @@ Stores the global information associated with an application.
 |**approval-program**  <br>*required*|\[approv\] approval program.  <br>**Pattern** : `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\|[A-Za-z0-9+/]{3}=)?$"`|string (byte)|
 |**clear-state-program**  <br>*required*|\[clearp\] approval program.  <br>**Pattern** : `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\|[A-Za-z0-9+/]{3}=)?$"`|string (byte)|
 |**creator**  <br>*required*|The address that created this application. This is the address where the parameters and global state for this application can be found.|string|
+|**extra-program-pages**  <br>*optional*|\[epp\] the amount of extra program pages available to this app.|integer|
 |**global-state**  <br>*optional*|[\gs\] global schema|[TealKeyValueStore](#tealkeyvaluestore)|
 |**global-state-schema**  <br>*optional*|[\lsch\] global schema|[ApplicationStateSchema](#applicationstateschema)|
 |**local-state-schema**  <br>*optional*|[\lsch\] local schema|[ApplicationStateSchema](#applicationstateschema)|

--- a/docs/reference/rest-apis/indexer.md
+++ b/docs/reference/rest-apis/indexer.md
@@ -657,6 +657,7 @@ data/basics/userBalance.go : AccountData
 |**amount**  <br>*required*|\[algo\] total number of MicroAlgos in the account|integer|
 |**amount-without-pending-rewards**  <br>*required*|specifies the amount of MicroAlgos in the account, without the pending rewards.|integer|
 |**apps-local-state**  <br>*optional*|\[appl\] applications local data stored in this account.<br><br>Note the raw object uses `map[int] -> AppLocalState` for this type.|< [ApplicationLocalState](#applicationlocalstate) > array|
+|**apps-total-extra-pages**  <br>*optional*|\[teap\] the sum of all extra application program pages for this account.|integer|
 |**apps-total-schema**  <br>*optional*|\[tsch\] stores the sum of all of the local schemas and global schemas in this account.<br><br>Note: the raw account uses `StateSchema` for this type.|[ApplicationStateSchema](#applicationstateschema)|
 |**assets**  <br>*optional*|\[asset\] assets held by this account.<br><br>Note the raw object uses `map[int] -> AssetHolding` for this type.|< [AssetHolding](#assetholding) > array|
 |**auth-addr**  <br>*optional*|\[spend\] the address against which signing should be checked. If empty, the address of the current account is used. This field can be updated in any transaction by setting the RekeyTo field.|string|
@@ -738,6 +739,7 @@ Stores the global information associated with an application.
 |**approval-program**  <br>*required*|\[approv\] approval program.  <br>**Pattern** : `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\|[A-Za-z0-9+/]{3}=)?$"`|string (byte)|
 |**clear-state-program**  <br>*required*|\[clearp\] approval program.  <br>**Pattern** : `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\|[A-Za-z0-9+/]{3}=)?$"`|string (byte)|
 |**creator**  <br>*optional*|The address that created this application. This is the address where the parameters and global state for this application can be found.|string|
+|**extra-program-pages**  <br>*optional*|\[epp\] the amount of extra program pages available to this app.|integer|
 |**global-state**  <br>*optional*|[\gs\] global schema|[TealKeyValueStore](#tealkeyvaluestore)|
 |**global-state-schema**  <br>*optional*|[\lsch\] global schema|[ApplicationStateSchema](#applicationstateschema)|
 |**local-state-schema**  <br>*optional*|[\lsch\] local schema|[ApplicationStateSchema](#applicationstateschema)|
@@ -1065,6 +1067,7 @@ data/transactions/application.go : ApplicationCallTxnFields
 |**application-id**  <br>*required*|\[apid\] ID of the application being configured or empty if creating.|integer|
 |**approval-program**  <br>*optional*|\[apap\] Logic executed for every application transaction, except when on-completion is set to "clear". It can read and write global state for the application, as well as account-specific local state. Approval programs may reject the transaction.  <br>**Pattern** : `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\|[A-Za-z0-9+/]{3}=)?$"`|string (byte)|
 |**clear-state-program**  <br>*optional*|\[apsu\] Logic executed for application transactions with on-completion set to "clear". It can read and write global state for the application, as well as account-specific local state. Clear state programs cannot reject the transaction.  <br>**Pattern** : `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\|[A-Za-z0-9+/]{3}=)?$"`|string (byte)|
+|**extra-program-pages**  <br>*optional*|\[epp\] specifies the additional app program len requested in pages.|integer|
 |**foreign-apps**  <br>*optional*|\[apfa\] Lists the applications in addition to the application-id whose global states may be accessed by this application's approval-program and clear-state-program. The access is read-only.|< integer > array|
 |**foreign-assets**  <br>*optional*|\[apas\] lists the assets whose parameters may be accessed by this application's ApprovalProgram and ClearStateProgram. The access is read-only.|< integer > array|
 |**global-state-schema**  <br>*optional*||[StateSchema](#stateschema)|

--- a/docs/reference/teal/opcodes.md
+++ b/docs/reference/teal/opcodes.md
@@ -18,8 +18,7 @@ Ops have a 'cost' of 1 unless otherwise specified.
 - SHA256 hash of value X, yields [32]byte
 - **Cost**:
    - 7 (LogicSigVersion = 1)
-   - 35 (LogicSigVersion = 2)
-   - 35 (LogicSigVersion = 3)
+   - 35 (2 <= LogicSigVersion <= 4)
 
 ## keccak256
 
@@ -29,8 +28,7 @@ Ops have a 'cost' of 1 unless otherwise specified.
 - Keccak256 hash of value X, yields [32]byte
 - **Cost**:
    - 26 (LogicSigVersion = 1)
-   - 130 (LogicSigVersion = 2)
-   - 130 (LogicSigVersion = 3)
+   - 130 (2 <= LogicSigVersion <= 4)
 
 ## sha512_256
 
@@ -40,8 +38,7 @@ Ops have a 'cost' of 1 unless otherwise specified.
 - SHA512_256 hash of value X, yields [32]byte
 - **Cost**:
    - 9 (LogicSigVersion = 1)
-   - 45 (LogicSigVersion = 2)
-   - 45 (LogicSigVersion = 3)
+   - 45 (2 <= LogicSigVersion <= 4)
 
 ## ed25519verify
 
@@ -76,6 +73,8 @@ Overflow is an error condition which halts execution and fails the transaction. 
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: uint64
 - A divided by B. Panic if B == 0.
+
+`divmodw` is available to divide the two-element values produced by `mulw` and `addw`.
 
 ## *
 
@@ -221,6 +220,15 @@ Overflow is an error condition which halts execution and fails the transaction. 
 - Pushes: *... stack*, uint64, uint64
 - A plus B out to 128-bit long result as sum (top) and carry-bit uint64 values on the stack
 - LogicSigVersion >= 2
+
+## divmodw
+
+- Opcode: 0x1f
+- Pops: *... stack*, {uint64 A}, {uint64 B}, {uint64 C}, {uint64 D}
+- Pushes: *... stack*, uint64, uint64, uint64, uint64
+- Pop four uint64 values.  The deepest two are interpreted as a uint128 dividend (deepest value is high word), the top two are interpreted as a uint128 divisor.  Four uint64 values are pushed to the stack. The deepest two are the quotient (deeper value is the high uint64). The top two are the remainder, low bits on top.
+- **Cost**: 20
+- LogicSigVersion >= 4
 
 ## intcblock uint ...
 
@@ -417,6 +425,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 | 53 | GlobalNumByteSlice | uint64 | Number of global state byteslices in ApplicationCall. LogicSigVersion >= 3. |
 | 54 | LocalNumUint | uint64 | Number of local state integers in ApplicationCall. LogicSigVersion >= 3. |
 | 55 | LocalNumByteSlice | uint64 | Number of local state byteslices in ApplicationCall. LogicSigVersion >= 3. |
+| 56 | ExtraProgramPages | uint64 | Number of additional pages for each of the application's approval and clear state programs. An ExtraProgramPages of 1 means 2048 more total bytes, or 1024 for each program. LogicSigVersion >= 4. |
 
 
 TypeEnum mapping:
@@ -501,7 +510,7 @@ for notes on transaction fields available, see `txn`. If this transaction is _i_
 - Opcode: 0x38 {uint8 transaction field index}
 - Pops: *... stack*, uint64
 - Pushes: any
-- push field F of the Ath transaction in the current group
+- push field F of the Xth transaction in the current group
 - LogicSigVersion >= 3
 
 for notes on transaction fields available, see `txn`. If top of stack is _i_, `gtxns field` is equivalent to `gtxn _i_ field`. gtxns exists so that _i_ can be calculated, often based on the index of the current transaction.
@@ -511,23 +520,67 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 - Opcode: 0x39 {uint8 transaction field index} {uint8 transaction field array index}
 - Pops: *... stack*, uint64
 - Pushes: any
-- push Ith value of the array field F from the Ath transaction in the current group
+- push Ith value of the array field F from the Xth transaction in the current group
 - LogicSigVersion >= 3
+
+## gload t i
+
+- Opcode: 0x3a {uint8 transaction group index} {uint8 position in scratch space to load from}
+- Pops: _None_
+- Pushes: any
+- push Ith scratch space index of the Tth transaction in the current group
+- LogicSigVersion >= 4
+- Mode: Application
+
+`gload` fails unless the requested transaction is an ApplicationCall and T < GroupIndex.
+
+## gloads i
+
+- Opcode: 0x3b {uint8 position in scratch space to load from}
+- Pops: *... stack*, uint64
+- Pushes: any
+- push Ith scratch space index of the Xth transaction in the current group
+- LogicSigVersion >= 4
+- Mode: Application
+
+`gloads` fails unless the requested transaction is an ApplicationCall and X < GroupIndex.
+
+## gaid t
+
+- Opcode: 0x3c
+- Pops: _None_
+- Pushes: uint64
+- push the ID of the asset or application created in the Tth transaction of the current group
+- LogicSigVersion >= 4
+- Mode: Application
+
+`gaid` fails unless the requested transaction created an asset or application and T < GroupIndex.
+
+## gaids
+
+- Opcode: 0x3d
+- Pops: *... stack*, uint64
+- Pushes: uint64
+- push the ID of the asset or application created in the Xth transaction of the current group
+- LogicSigVersion >= 4
+- Mode: Application
+
+`gaids` fails unless the requested transaction created an asset or application and X < GroupIndex.
 
 ## bnz target
 
-- Opcode: 0x40 {0..0x7fff forward branch offset, big endian}
+- Opcode: 0x40 {int16 branch offset, big endian}
 - Pops: *... stack*, uint64
 - Pushes: _None_
 - branch to TARGET if value X is not zero
 
-The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which are a high byte first and low byte second which together form a 16 bit offset which the instruction may branch to. For a bnz instruction at `pc`, if the last element of the stack is not zero then branch to instruction at `pc + 3 + N`, else proceed to next instruction at `pc + 3`. Branch targets must be well aligned instructions. (e.g. Branching to the second byte of a 2 byte op will be rejected.) Branch offsets are currently limited to forward branches only, 0-0x7fff. A future expansion might make this a signed 16 bit integer allowing for backward branches and looping.
+The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which are a high byte first and low byte second which together form a 16 bit offset which the instruction may branch to. For a bnz instruction at `pc`, if the last element of the stack is not zero then branch to instruction at `pc + 3 + N`, else proceed to next instruction at `pc + 3`. Branch targets must be aligned instructions. (e.g. Branching to the second byte of a 2 byte op will be rejected.) Starting at v4, the offset is treated as a signed 16 bit integer allowing for backward branches and looping. In prior version (v1 to v3), branch offsets are limited to forward branches only, 0-0x7fff.
 
-At LogicSigVersion 2 it became allowed to branch to the end of the program exactly after the last instruction: bnz to byte N (with 0-indexing) was illegal for a TEAL program with N bytes before LogicSigVersion 2, and is legal after it. This change eliminates the need for a last instruction of no-op as a branch target at the end. (Branching beyond the end--in other words, to a byte larger than N--is still illegal and will cause the program to fail.)
+At v2 it became allowed to branch to the end of the program exactly after the last instruction: bnz to byte N (with 0-indexing) was illegal for a TEAL program with N bytes before v2, and is legal after it. This change eliminates the need for a last instruction of no-op as a branch target at the end. (Branching beyond the end--in other words, to a byte larger than N--is still illegal and will cause the program to fail.)
 
 ## bz target
 
-- Opcode: 0x41 {0..0x7fff forward branch offset, big endian}
+- Opcode: 0x41 {int16 branch offset, big endian}
 - Pops: *... stack*, uint64
 - Pushes: _None_
 - branch to TARGET if value X is zero
@@ -537,7 +590,7 @@ See `bnz` for details on how branches work. `bz` inverts the behavior of `bnz`.
 
 ## b target
 
-- Opcode: 0x42 {0..0x7fff forward branch offset, big endian}
+- Opcode: 0x42 {int16 branch offset, big endian}
 - Pops: _None_
 - Pushes: _None_
 - branch unconditionally to TARGET
@@ -647,11 +700,11 @@ see explanation of bit ordering in setbit
 
 - Opcode: 0x54
 - Pops: *... stack*, {any A}, {uint64 B}, {uint64 C}
-- Pushes: uint64
+- Pushes: any
 - pop a target A, index B, and bit C. Set the Bth bit of A to C, and push the result
 - LogicSigVersion >= 3
 
-bit indexing begins with low-order bits in integers. Setting bit 4 to 1 on the integer 0 yields 16 (`int 0x0010`, or 2^4). Indexing begins in the first bytes of a byte-string (as seen in getbyte and substring). Setting bits 0 through 11 to 1 in a 4 byte-array of 0s yields `byte 0xfff00000`
+When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on the integer 0 yields 8, or 2^3. When A is a byte array, index 0 is the leftmost bit of the leftmost byte. Setting bits 0 through 11 to 1 in a 4-byte-array of 0s yields the byte array 0xfff00000. Setting bit 3 to 1 on the 1-byte-array 0x00 yields the byte array 0x10.
 
 ## getbyte
 
@@ -672,44 +725,46 @@ bit indexing begins with low-order bits in integers. Setting bit 4 to 1 on the i
 ## balance
 
 - Opcode: 0x60
-- Pops: *... stack*, uint64
+- Pops: *... stack*, any
 - Pushes: uint64
-- get balance for the requested account specified by Txn.Accounts[A] in microalgos. A is specified as an account index in the Accounts field of the ApplicationCall transaction, zero index means the sender. The balance is observed after the effects of previous transactions in the group, and after the fee for the current transaction is deducted.
+- get balance for account A, in microalgos. The balance is observed after the effects of previous transactions in the group, and after the fee for the current transaction is deducted.
 - LogicSigVersion >= 2
 - Mode: Application
+
+params: Before v4, Txn.Accounts offset. Since v4, Txn.Accounts offset or an account address that appears in Txn.Accounts or is Txn.Sender). Return: value.
 
 ## app_opted_in
 
 - Opcode: 0x61
-- Pops: *... stack*, {uint64 A}, {uint64 B}
+- Pops: *... stack*, {any A}, {uint64 B}
 - Pushes: uint64
-- check if account specified by Txn.Accounts[A] opted in for the application B => {0 or 1}
+- check if account A opted in for the application B => {0 or 1}
 - LogicSigVersion >= 2
 - Mode: Application
 
-params: account index, application id (top of the stack on opcode entry). Return: 1 if opted in and 0 otherwise.
+params: Txn.Accounts offset (or, since v4, an account address that appears in Txn.Accounts or is Txn.Sender), application id (or, since v4, a Txn.ForeignApps offset). Return: 1 if opted in and 0 otherwise.
 
 ## app_local_get
 
 - Opcode: 0x62
-- Pops: *... stack*, {uint64 A}, {[]byte B}
+- Pops: *... stack*, {any A}, {[]byte B}
 - Pushes: any
-- read from account specified by Txn.Accounts[A] from local state of the current application key B => value
+- read from account A from local state of the current application key B => value
 - LogicSigVersion >= 2
 - Mode: Application
 
-params: account index, state key. Return: value. The value is zero (of type uint64) if the key does not exist.
+params: Txn.Accounts offset (or, since v4, an account address that appears in Txn.Accounts or is Txn.Sender), state key. Return: value. The value is zero (of type uint64) if the key does not exist.
 
 ## app_local_get_ex
 
 - Opcode: 0x63
-- Pops: *... stack*, {uint64 A}, {uint64 B}, {[]byte C}
+- Pops: *... stack*, {any A}, {uint64 B}, {[]byte C}
 - Pushes: *... stack*, any, uint64
-- read from account specified by Txn.Accounts[A] from local state of the application B key C => [*... stack*, value, 0 or 1]
+- read from account A from local state of the application B key C => [*... stack*, value, 0 or 1]
 - LogicSigVersion >= 2
 - Mode: Application
 
-params: account index, application id, state key. Return: did_exist flag (top of the stack, 1 if exist and 0 otherwise), value. The value is zero (of type uint64) if the key does not exist.
+params: Txn.Accounts offset (or, since v4, an account address that appears in Txn.Accounts or is Txn.Sender), application id (or, since v4, a Txn.ForeignApps offset), state key. Return: did_exist flag (top of the stack, 1 if exist and 0 otherwise), value. The value is zero (of type uint64) if the key does not exist.
 
 ## app_global_get
 
@@ -727,22 +782,22 @@ params: state key. Return: value. The value is zero (of type uint64) if the key 
 - Opcode: 0x65
 - Pops: *... stack*, {uint64 A}, {[]byte B}
 - Pushes: *... stack*, any, uint64
-- read from application Txn.ForeignApps[A] global state key B => [*... stack*, value, 0 or 1]. A is specified as an account index in the ForeignApps field of the ApplicationCall transaction, zero index means this app
+- read from application A global state key B => [*... stack*, value, 0 or 1]
 - LogicSigVersion >= 2
 - Mode: Application
 
-params: application index, state key. Return: did_exist flag (top of the stack, 1 if exist and 0 otherwise), value. The value is zero (of type uint64) if the key does not exist.
+params: Txn.ForeignApps offset (or, since v4, an application id that appears in Txn.ForeignApps or is the CurrentApplicationID), state key. Return: did_exist flag (top of the stack, 1 if exist and 0 otherwise), value. The value is zero (of type uint64) if the key does not exist.
 
 ## app_local_put
 
 - Opcode: 0x66
-- Pops: *... stack*, {uint64 A}, {[]byte B}, {any C}
+- Pops: *... stack*, {any A}, {[]byte B}, {any C}
 - Pushes: _None_
-- write to account specified by Txn.Accounts[A] to local state of a current application key B with value C
+- write to account specified by A to local state of a current application key B with value C
 - LogicSigVersion >= 2
 - Mode: Application
 
-params: account index, state key, value.
+params: Txn.Accounts offset (or, since v4, an account address that appears in Txn.Accounts or is Txn.Sender), state key, value.
 
 ## app_global_put
 
@@ -756,13 +811,13 @@ params: account index, state key, value.
 ## app_local_del
 
 - Opcode: 0x68
-- Pops: *... stack*, {uint64 A}, {[]byte B}
+- Pops: *... stack*, {any A}, {[]byte B}
 - Pushes: _None_
-- delete from account specified by Txn.Accounts[A] local state key B of the current application
+- delete from account A local state key B of the current application
 - LogicSigVersion >= 2
 - Mode: Application
 
-params: account index, state key.
+params: Txn.Accounts offset (or, since v4, an account address that appears in Txn.Accounts or is Txn.Sender), state key.
 
 Deleting a key which is already absent has no effect on the application local state. (In particular, it does _not_ cause the program to fail.)
 
@@ -782,9 +837,9 @@ Deleting a key which is already absent has no effect on the application global s
 ## asset_holding_get i
 
 - Opcode: 0x70 {uint8 asset holding field index}
-- Pops: *... stack*, {uint64 A}, {uint64 B}
+- Pops: *... stack*, {any A}, {uint64 B}
 - Pushes: *... stack*, any, uint64
-- read from account specified by Txn.Accounts[A] and asset B holding field X (imm arg) => {0 or 1 (top), value}
+- read from account A and asset B holding field X (imm arg) => {0 or 1 (top), value}
 - LogicSigVersion >= 2
 - Mode: Application
 
@@ -796,14 +851,14 @@ Deleting a key which is already absent has no effect on the application global s
 | 1 | AssetFrozen | uint64 | Is the asset frozen or not |
 
 
-params: account index, asset id. Return: did_exist flag (1 if exist and 0 otherwise), value.
+params: Txn.Accounts offset (or, since v4, an account address that appears in Txn.Accounts or is Txn.Sender), asset id (or, since v4, a Txn.ForeignAssets offset). Return: did_exist flag (1 if exist and 0 otherwise), value.
 
 ## asset_params_get i
 
 - Opcode: 0x71 {uint8 asset params field index}
 - Pops: *... stack*, uint64
 - Pushes: *... stack*, any, uint64
-- read from asset Txn.ForeignAssets[A] params field X (imm arg) => {0 or 1 (top), value}
+- read from asset A params field X (imm arg) => {0 or 1 (top), value}
 - LogicSigVersion >= 2
 - Mode: Application
 
@@ -824,16 +879,18 @@ params: account index, asset id. Return: did_exist flag (1 if exist and 0 otherw
 | 10 | AssetClawback | []byte | Clawback address |
 
 
-params: txn.ForeignAssets offset. Return: did_exist flag (1 if exist and 0 otherwise), value.
+params: Before v4, Txn.ForeignAssets offset. Since v4, Txn.ForeignAssets offset or an asset id that appears in Txn.ForeignAssets. Return: did_exist flag (1 if exist and 0 otherwise), value.
 
 ## min_balance
 
 - Opcode: 0x78
-- Pops: *... stack*, uint64
+- Pops: *... stack*, any
 - Pushes: uint64
-- get minimum required balance for the requested account specified by Txn.Accounts[A] in microalgos. A is specified as an account index in the Accounts field of the ApplicationCall transaction, zero index means the sender. Required balance is affected by [ASA](https://developer.algorand.org/docs/features/asa/#assets-overview) and [App](https://developer.algorand.org/docs/features/asc1/stateful/#minimum-balance-requirement-for-a-smart-contract) usage. When creating or opting into an app, the minimum balance grows before the app code runs, therefore the increase is visible there. When deleting or closing out, the minimum balance decreases after the app executes.
+- get minimum required balance for account A, in microalgos. Required balance is affected by [ASA](https://developer.algorand.org/docs/features/asa/#assets-overview) and [App](https://developer.algorand.org/docs/features/asc1/stateful/#minimum-balance-requirement-for-a-smart-contract) usage. When creating or opting into an app, the minimum balance grows before the app code runs, therefore the increase is visible there. When deleting or closing out, the minimum balance decreases after the app executes.
 - LogicSigVersion >= 3
 - Mode: Application
+
+params: Before v4, Txn.Accounts offset. Since v4, Txn.Accounts offset or an account address that appears in Txn.Accounts or is Txn.Sender). Return: value.
 
 ## pushbytes bytes
 
@@ -854,3 +911,212 @@ pushbytes args are not added to the bytecblock during assembly processes
 - LogicSigVersion >= 3
 
 pushint args are not added to the intcblock during assembly processes
+
+## callsub target
+
+- Opcode: 0x88
+- Pops: _None_
+- Pushes: _None_
+- branch unconditionally to TARGET, saving the next instruction on the call stack
+- LogicSigVersion >= 4
+
+The call stack is separate from the data stack. Only `callsub` and `retsub` manipulate it.
+
+## retsub
+
+- Opcode: 0x89
+- Pops: _None_
+- Pushes: _None_
+- pop the top instruction from the call stack and branch to it
+- LogicSigVersion >= 4
+
+The call stack is separate from the data stack. Only `callsub` and `retsub` manipulate it.
+
+## shl
+
+- Opcode: 0x90
+- Pops: *... stack*, {uint64 A}, {uint64 B}
+- Pushes: uint64
+- A times 2^B, modulo 2^64
+- LogicSigVersion >= 4
+
+## shr
+
+- Opcode: 0x91
+- Pops: *... stack*, {uint64 A}, {uint64 B}
+- Pushes: uint64
+- A divided by 2^B
+- LogicSigVersion >= 4
+
+## sqrt
+
+- Opcode: 0x92
+- Pops: *... stack*, uint64
+- Pushes: uint64
+- The largest integer B such that B^2 <= X
+- **Cost**: 4
+- LogicSigVersion >= 4
+
+## bitlen
+
+- Opcode: 0x93
+- Pops: *... stack*, any
+- Pushes: uint64
+- The highest set bit in X. If X is a byte-array, it is interpreted as a big-endian unsigned integer. bitlen of 0 is 0, bitlen of 8 is 4
+- LogicSigVersion >= 4
+
+bitlen interprets arrays as big-endian integers, unlike setbit/getbit
+
+## exp
+
+- Opcode: 0x94
+- Pops: *... stack*, {uint64 A}, {uint64 B}
+- Pushes: uint64
+- A raised to the Bth power. Panic if A == B == 0 and on overflow
+- LogicSigVersion >= 4
+
+## expw
+
+- Opcode: 0x95
+- Pops: *... stack*, {uint64 A}, {uint64 B}
+- Pushes: *... stack*, uint64, uint64
+- A raised to the Bth power as a 128-bit long result as low (top) and high uint64 values on the stack. Panic if A == B == 0 or if the results exceeds 2^128-1
+- **Cost**: 10
+- LogicSigVersion >= 4
+
+## b+
+
+- Opcode: 0xa0
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: []byte
+- A plus B, where A and B are byte-arrays interpreted as big-endian unsigned integers
+- **Cost**: 10
+- LogicSigVersion >= 4
+
+## b-
+
+- Opcode: 0xa1
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: []byte
+- A minus B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic on underflow.
+- **Cost**: 10
+- LogicSigVersion >= 4
+
+## b/
+
+- Opcode: 0xa2
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: []byte
+- A divided by B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic if B is zero.
+- **Cost**: 20
+- LogicSigVersion >= 4
+
+## b*
+
+- Opcode: 0xa3
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: []byte
+- A times B, where A and B are byte-arrays interpreted as big-endian unsigned integers.
+- **Cost**: 20
+- LogicSigVersion >= 4
+
+## b<
+
+- Opcode: 0xa4
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: uint64
+- A is less than B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1}
+- LogicSigVersion >= 4
+
+## b>
+
+- Opcode: 0xa5
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: uint64
+- A is greater than B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1}
+- LogicSigVersion >= 4
+
+## b<=
+
+- Opcode: 0xa6
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: uint64
+- A is less than or equal to B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1}
+- LogicSigVersion >= 4
+
+## b>=
+
+- Opcode: 0xa7
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: uint64
+- A is greater than or equal to B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1}
+- LogicSigVersion >= 4
+
+## b==
+
+- Opcode: 0xa8
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: uint64
+- A is equals to B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1}
+- LogicSigVersion >= 4
+
+## b!=
+
+- Opcode: 0xa9
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: uint64
+- A is not equal to B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1}
+- LogicSigVersion >= 4
+
+## b%
+
+- Opcode: 0xaa
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: []byte
+- A modulo B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic if B is zero.
+- **Cost**: 20
+- LogicSigVersion >= 4
+
+## b|
+
+- Opcode: 0xab
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: []byte
+- A bitwise-or B, where A and B are byte-arrays, zero-left extended to the greater of their lengths
+- **Cost**: 6
+- LogicSigVersion >= 4
+
+## b&
+
+- Opcode: 0xac
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: []byte
+- A bitwise-and B, where A and B are byte-arrays, zero-left extended to the greater of their lengths
+- **Cost**: 6
+- LogicSigVersion >= 4
+
+## b^
+
+- Opcode: 0xad
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: []byte
+- A bitwise-xor B, where A and B are byte-arrays, zero-left extended to the greater of their lengths
+- **Cost**: 6
+- LogicSigVersion >= 4
+
+## b~
+
+- Opcode: 0xae
+- Pops: *... stack*, []byte
+- Pushes: []byte
+- X with all bits inverted
+- **Cost**: 4
+- LogicSigVersion >= 4
+
+## bzero
+
+- Opcode: 0xaf
+- Pops: *... stack*, uint64
+- Pushes: []byte
+- push a byte-array of length X, containing all zero bytes
+- LogicSigVersion >= 4

--- a/docs/reference/teal/specification.md
+++ b/docs/reference/teal/specification.md
@@ -1,8 +1,7 @@
 title: Transaction Execution Approval Language (TEAL)
 
-TEAL is a bytecode based stack language that executes inside Algorand transactions to check the parameters of the transaction and approve the transaction as if by a signature. Programs have read-only access to the transaction they are attached to, transactions in their atomic transaction group, and a few global values. Programs cannot modify or create transactions, only reject or approve them. Approval is signaled by finishing with the stack containing a single non-zero uint64 value.
-
-TEAL programs should be short and run fast as they are run in-line along with signature checking, transaction balance rule checking, and other checks during block assembly and validation. Many useful programs are less than 100 instructions.
+TEAL is a bytecode based stack language that executes inside Algorand transactions. TEAL programs can be used to check the parameters of the transaction and approve the transaction as if by a signature. This use of TEAL is called a _LogicSig_. Starting with v2, TEAL programs may
+also execute as _Applications_ which are invoked with explicit application call transactions. Programs have read-only access to the transaction they are attached to, transactions in their atomic transaction group, and a few global values. In addition, _Application_ programs have access to limited state that is global to the application and per-account local state for each account that has opted-in to the application. Programs cannot modify or create transactions, only reject or approve them. For both types of program, approval is signaled by finishing with the stack containing a single non-zero uint64 value.
 
 ## The Stack
 
@@ -14,9 +13,20 @@ The maximum stack depth is currently 1000.
 
 In addition to the stack there are 256 positions of scratch space, also uint64-bytes union values, accessed by the `load` and `store` ops moving data from or to scratch space, respectively.
 
-## Execution Environment
+## Execution Modes
 
-TEAL runs in Algorand nodes as part of testing a proposed transaction to see if it is valid and authorized to be committed into a block.
+Starting from version 2 TEAL evaluator can run programs in two modes:
+1. LogicSig (stateless)
+2. Application run (stateful)
+
+Differences between modes include:
+1. Max program length (consensus parameters LogicSigMaxSize, MaxAppTotalProgramLen & MaxExtraAppProgramPages)
+2. Max program cost (consensus parameters LogicSigMaxCost, MaxAppProgramCost)
+3. Opcode availability. For example, all stateful operations are only available in stateful mode. Refer to [opcodes document](opcodes.md) for details.
+
+## Execution Environment for LogicSigs
+
+TEAL LogicSigs run in Algorand nodes as part of testing a proposed transaction to see if it is valid and authorized to be committed into a block.
 
 If an authorized program executes and finishes with a single non-zero uint64 value on the stack then that program has validated the transaction it is attached to.
 
@@ -27,28 +37,17 @@ A program can either authorize some delegated action on a normal private key sig
 * If the account has signed the program (an ed25519 signature on "Program" concatenated with the program bytes) then if the program returns true the transaction is authorized as if the account had signed it. This allows an account to hand out a signed program so that other users can carry out delegated actions which are approved by the program.
 * If the SHA512_256 hash of the program (prefixed by "Program") is equal to the transaction Sender address then this is a contract account wholly controlled by the program. No other signature is necessary or possible. The only way to execute a transaction against the contract account is for the program to approve it.
 
-The TEAL bytecode plus the length of any Args must add up to less than 1000 bytes (consensus parameter LogicSigMaxSize). Each TEAL op has an associated cost estimate and the program cost estimate must total less than 20000 (consensus parameter LogicSigMaxCost). Most ops have an estimated cost of 1, but a few slow crypto ops are much higher.
-
-## Execution modes
-
-Starting from version 2 TEAL evaluator can run programs in two modes:
-1. Signature verification (stateless)
-2. Application run (stateful)
-
-Differences between modes include:
-1. Max program length (consensus parameters LogicSigMaxSize, MaxApprovalProgramLen and MaxClearStateProgramLen)
-2. Max program cost (consensus parameters LogicSigMaxCost, MaxAppProgramCost)
-3. Opcodes availability. For example, all stateful operations are only available in stateful mode. Refer to [opcodes document](opcodes.md) for details.
+The TEAL bytecode plus the length of any Args must add up to less than 1000 bytes (consensus parameter LogicSigMaxSize). Each TEAL op has an associated cost and the program cost must total less than 20000 (consensus parameter LogicSigMaxCost). Most ops have a cost of 1, but a few slow crypto ops are much higher. Prior to v4, the program's cost was estimated as the static sum of all the opcode costs in the program (whether they were actually executed or not). Beginning with v4, the program's cost is tracked dynamically, while being evaluated. If the program exceeds its budget, it fails.
 
 ## Constants
 
-Constants are loaded into the environment into storage separate from the stack. They can then be pushed onto the stack by referring to the type and index. This makes for efficient re-use of byte constants used for account addresses, etc.
+Constants are loaded into the environment into storage separate from the stack. They can then be pushed onto the stack by referring to the type and index. This makes for efficient re-use of byte constants used for account addresses, etc. Constants that are not reused can be pushed with `pushint` or `pushbytes`.
 
 The assembler will hide most of this, allowing simple use of `int 1234` and `byte 0xcafed00d`. These constants will automatically get assembled into int and byte pages of constants, de-duplicated, and operations to load them from constant storage space inserted.
 
 Constants are loaded into the environment by two opcodes, `intcblock` and `bytecblock`. Both of these use [proto-buf style variable length unsigned int](https://developers.google.com/protocol-buffers/docs/encoding#varint), reproduced [here](#varuint). The `intcblock` opcode is followed by a varuint specifying the length of the array and then that number of varuint. The `bytecblock` opcode is followed by a varuint array length then that number of pairs of (varuint, bytes) length prefixed byte strings. This should efficiently load 32 and 64 byte constants which will be common as addresses, hashes, and signatures.
 
-Constants are pushed onto the stack by `intc`, `intc_[0123]`, `bytec`, and `bytec_[0123]`. The assembler will handle converting `int N` or `byte N` into the appropriate form of the instruction needed.
+Constants are pushed onto the stack by `intc`, `intc_[0123]`, `pushint`, `bytec`, `bytec_[0123]`, and `pushbytes`. The assembler will handle converting `int N` or `byte N` into the appropriate form of the instruction needed.
 
 ### Named Integer Constants
 
@@ -80,11 +79,8 @@ An application transaction must indicate the action to be taken following the ex
 ## Operations
 
 Most operations work with only one type of argument, uint64 or bytes, and panic if the wrong type value is on the stack.
-The instruction set was designed to execute calculator-like expressions.
-What might be a one line expression with various parenthesized clauses should be efficiently representable in TEAL.
 
-Looping is not possible, by design, to ensure predictably fast execution.
-There is a branch instruction (`bnz`, branch if not zero) which allows forward branching only so that some code may be skipped.
+Many instructions accept values to designate Accounts, Assets, or Applications. Beginning with TEAL v4, these values may always be given as an _offset_ in the corresponding Txn fields (Txn.Accounts, Txn.ForeignAssets, Txn.ForeignApps) _or_ as the value itself (a bytes address for Accounts, or a uint64 ID). The values, however, must still be present in the Txn fields. Before TEAL v4, most opcodes required the use of an offset, except for reading account local values of assets or applications, which accepted the IDs directly and did not require the ID to be present in they corresponding _Foreign_ array. (Note that beginning with TEAL v4, those ID are required to be present in their corresponding _Foreign_ array.) See individual opcodes for details. In the case of account offsets or application offsets, 0 is specially defined to Txn.Sender or the ID of the current application, respectively.
 
 Many programs need only a few dozen instructions. The instruction set has some optimization built in. `intc`, `bytec`, and `arg` take an immediate value byte, making a 2-byte op to load a value onto the stack, but they also have single byte versions for loading the most common constant values. Any program will benefit from having a few common values loaded with a smaller one byte opcode. Cryptographic hashes and `ed25519verify` are single byte opcodes with powerful libraries behind them. These operations still take more time than other ops (and this is reflected in the cost of each op and the cost limit of a program) but are efficient in compiled code space.
 
@@ -98,7 +94,9 @@ A contract account governed by a buggy program might not have a way to get asset
 
 For one-argument ops, `X` is the last element on the stack, which is typically replaced by a new value.
 
-For two-argument ops, `A` is the previous element on the stack and `B` is the last element on the stack. These typically result in popping A and B from the stack and pushing the result.
+For two-argument ops, `A` is the penultimate element on the stack and `B` is the top of the stack. These typically result in popping A and B from the stack and pushing the result.
+
+For three-argument ops, `A` is the element two below the top, `B` is the penultimate stack element and `C` is the top of the stack. These operatiosn typically pop A, B, and C from the stack and push the result.
 
 | Op | Description |
 | --- | --- |
@@ -116,6 +114,11 @@ For two-argument ops, `A` is the previous element on the stack and `B` is the la
 | `>=` | A greater than or equal to B => {0 or 1} |
 | `&&` | A is not zero and B is not zero => {0 or 1} |
 | `\|\|` | A is not zero or B is not zero => {0 or 1} |
+| `shl` | A times 2^B, modulo 2^64 |
+| `shr` | A divided by 2^B |
+| `sqrt` | The largest integer B such that B^2 <= X |
+| `bitlen` | The highest set bit in X. If X is a byte-array, it is interpreted as a big-endian unsigned integer. bitlen of 0 is 0, bitlen of 8 is 4 |
+| `exp` | A raised to the Bth power. Panic if A == B == 0 and on overflow |
 | `==` | A is equal to B => {0 or 1} |
 | `!=` | A is not equal to B => {0 or 1} |
 | `!` | X == 0 yields 1; else 0 |
@@ -129,6 +132,8 @@ For two-argument ops, `A` is the previous element on the stack and `B` is the la
 | `~` | bitwise invert value X |
 | `mulw` | A times B out to 128-bit long result as low (top) and high uint64 values on the stack |
 | `addw` | A plus B out to 128-bit long result as sum (top) and carry-bit uint64 values on the stack |
+| `divmodw` | Pop four uint64 values.  The deepest two are interpreted as a uint128 dividend (deepest value is high word), the top two are interpreted as a uint128 divisor.  Four uint64 values are pushed to the stack. The deepest two are the quotient (deeper value is the high uint64). The top two are the remainder, low bits on top. |
+| `expw` | A raised to the Bth power as a 128-bit long result as low (top) and high uint64 values on the stack. Panic if A == B == 0 or if the results exceeds 2^128-1 |
 | `getbit` | pop a target A (integer or byte-array), and index B. Push the Bth bit of A. |
 | `setbit` | pop a target A, index B, and bit C. Set the Bth bit of A to C, and push the result |
 | `getbyte` | pop a byte-array A and integer B. Extract the Bth byte of A and push it as an integer |
@@ -136,6 +141,46 @@ For two-argument ops, `A` is the previous element on the stack and `B` is the la
 | `concat` | pop two byte-arrays A and B and join them, push the result |
 | `substring s e` | pop a byte-array A. For immediate values in 0..255 S and E: extract a range of bytes from A starting at S up to but not including E, push the substring result. If E < S, or either is larger than the array length, the program fails |
 | `substring3` | pop a byte-array A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result. If C < B, or either is larger than the array length, the program fails |
+
+These opcodes take byte-array values that are interpreted as
+big-endian unsigned integers.  For mathematical operators, the
+returned values are the shortest byte-array that can represent the
+returned value.  For example, the zero value is the empty
+byte-array. For comparison operators, the returned value is a uint64
+
+Input lengths are limited to a maximum length 64 bytes, which
+represents a 512 bit unsigned integer. Output lengths are not
+explicitly restricted, though only `b*` and `b+` can produce a larger
+output than their inputs, so there is an implicit length limit of 128
+bytes on outputs.
+
+| Op | Description |
+| --- | --- |
+| `b+` | A plus B, where A and B are byte-arrays interpreted as big-endian unsigned integers |
+| `b-` | A minus B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic on underflow. |
+| `b/` | A divided by B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic if B is zero. |
+| `b*` | A times B, where A and B are byte-arrays interpreted as big-endian unsigned integers. |
+| `b<` | A is less than B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1} |
+| `b>` | A is greater than B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1} |
+| `b<=` | A is less than or equal to B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1} |
+| `b>=` | A is greater than or equal to B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1} |
+| `b==` | A is equals to B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1} |
+| `b!=` | A is not equal to B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1} |
+| `b%` | A modulo B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic if B is zero. |
+
+These opcodes operate on the bits of byte-array values.  The shorter
+array is interpeted as though left padded with zeros until it is the
+same length as the other input.  The returned values are the same
+length as the longest input.  Therefore, unlike array arithmetic,
+these results may contain leading zero bytes.
+
+| Op | Description |
+| --- | --- |
+| `b\|` | A bitwise-or B, where A and B are byte-arrays, zero-left extended to the greater of their lengths |
+| `b&` | A bitwise-and B, where A and B are byte-arrays, zero-left extended to the greater of their lengths |
+| `b^` | A bitwise-xor B, where A and B are byte-arrays, zero-left extended to the greater of their lengths |
+| `b~` | X with all bits inverted |
+
 
 ### Loading Values
 
@@ -159,6 +204,7 @@ Some of these have immediate data in the byte or bytes after the opcode.
 | `bytec_2` | push constant 2 from bytecblock to stack |
 | `bytec_3` | push constant 3 from bytecblock to stack |
 | `pushbytes bytes` | push the following program bytes to the stack |
+| `bzero` | push a byte-array of length X, containing all zero bytes |
 | `arg n` | push Nth LogicSig argument to stack |
 | `arg_0` | push LogicSig argument 0 to stack |
 | `arg_1` | push LogicSig argument 1 to stack |
@@ -168,11 +214,15 @@ Some of these have immediate data in the byte or bytes after the opcode.
 | `gtxn t f` | push field F of the Tth transaction in the current group |
 | `txna f i` | push Ith value of the array field F of the current transaction |
 | `gtxna t f i` | push Ith value of the array field F from the Tth transaction in the current group |
-| `gtxns f` | push field F of the Ath transaction in the current group |
-| `gtxnsa f i` | push Ith value of the array field F from the Ath transaction in the current group |
+| `gtxns f` | push field F of the Xth transaction in the current group |
+| `gtxnsa f i` | push Ith value of the array field F from the Xth transaction in the current group |
 | `global f` | push value from globals to stack |
 | `load i` | copy a value from scratch space to the stack |
 | `store i` | pop a value from the stack and store to scratch space |
+| `gload t i` | push Ith scratch space index of the Tth transaction in the current group |
+| `gloads i` | push Ith scratch space index of the Xth transaction in the current group |
+| `gaid t` | push the ID of the asset or application created in the Tth transaction of the current group |
+| `gaids` | push the ID of the asset or application created in the Xth transaction of the current group |
 
 **Transaction Fields**
 
@@ -234,6 +284,7 @@ Some of these have immediate data in the byte or bytes after the opcode.
 | 53 | GlobalNumByteSlice | uint64 | Number of global state byteslices in ApplicationCall. LogicSigVersion >= 3. |
 | 54 | LocalNumUint | uint64 | Number of local state integers in ApplicationCall. LogicSigVersion >= 3. |
 | 55 | LocalNumByteSlice | uint64 | Number of local state byteslices in ApplicationCall. LogicSigVersion >= 3. |
+| 56 | ExtraProgramPages | uint64 | Number of additional pages for each of the application's approval and clear state programs. An ExtraProgramPages of 1 means 2048 more total bytes, or 1024 for each program. LogicSigVersion >= 4. |
 
 
 Additional details in the [opcodes document](opcodes.md#txn) on the `txn` op.
@@ -297,24 +348,26 @@ Asset fields include `AssetHolding` and `AssetParam` fields that are used in `as
 | `swap` | swaps two last values on stack: A, B -> B, A |
 | `select` | selects one of two values based on top-of-stack: A, B, C -> (if C != 0 then B else A) |
 | `assert` | immediately fail unless value X is a non-zero number |
+| `callsub target` | branch unconditionally to TARGET, saving the next instruction on the call stack |
+| `retsub` | pop the top instruction from the call stack and branch to it |
 
 ### State Access
 
 | Op | Description |
 | --- | --- |
-| `balance` | get balance for the requested account specified by Txn.Accounts[A] in microalgos. A is specified as an account index in the Accounts field of the ApplicationCall transaction, zero index means the sender. The balance is observed after the effects of previous transactions in the group, and after the fee for the current transaction is deducted. |
-| `min_balance` | get minimum required balance for the requested account specified by Txn.Accounts[A] in microalgos. A is specified as an account index in the Accounts field of the ApplicationCall transaction, zero index means the sender. Required balance is affected by [ASA](https://developer.algorand.org/docs/features/asa/#assets-overview) and [App](https://developer.algorand.org/docs/features/asc1/stateful/#minimum-balance-requirement-for-a-smart-contract) usage. When creating or opting into an app, the minimum balance grows before the app code runs, therefore the increase is visible there. When deleting or closing out, the minimum balance decreases after the app executes. |
-| `app_opted_in` | check if account specified by Txn.Accounts[A] opted in for the application B => {0 or 1} |
-| `app_local_get` | read from account specified by Txn.Accounts[A] from local state of the current application key B => value |
-| `app_local_get_ex` | read from account specified by Txn.Accounts[A] from local state of the application B key C => [*... stack*, value, 0 or 1] |
+| `balance` | get balance for account A, in microalgos. The balance is observed after the effects of previous transactions in the group, and after the fee for the current transaction is deducted. |
+| `min_balance` | get minimum required balance for account A, in microalgos. Required balance is affected by [ASA](https://developer.algorand.org/docs/features/asa/#assets-overview) and [App](https://developer.algorand.org/docs/features/asc1/stateful/#minimum-balance-requirement-for-a-smart-contract) usage. When creating or opting into an app, the minimum balance grows before the app code runs, therefore the increase is visible there. When deleting or closing out, the minimum balance decreases after the app executes. |
+| `app_opted_in` | check if account A opted in for the application B => {0 or 1} |
+| `app_local_get` | read from account A from local state of the current application key B => value |
+| `app_local_get_ex` | read from account A from local state of the application B key C => [*... stack*, value, 0 or 1] |
 | `app_global_get` | read key A from global state of a current application => value |
-| `app_global_get_ex` | read from application Txn.ForeignApps[A] global state key B => [*... stack*, value, 0 or 1]. A is specified as an account index in the ForeignApps field of the ApplicationCall transaction, zero index means this app |
-| `app_local_put` | write to account specified by Txn.Accounts[A] to local state of a current application key B with value C |
+| `app_global_get_ex` | read from application A global state key B => [*... stack*, value, 0 or 1] |
+| `app_local_put` | write to account specified by A to local state of a current application key B with value C |
 | `app_global_put` | write key A and value B to global state of the current application |
-| `app_local_del` | delete from account specified by Txn.Accounts[A] local state key B of the current application |
+| `app_local_del` | delete from account A local state key B of the current application |
 | `app_global_del` | delete key A from a global state of the current application |
-| `asset_holding_get i` | read from account specified by Txn.Accounts[A] and asset B holding field X (imm arg) => {0 or 1 (top), value} |
-| `asset_params_get i` | read from asset Txn.ForeignAssets[A] params field X (imm arg) => {0 or 1 (top), value} |
+| `asset_holding_get i` | read from account A and asset B holding field X (imm arg) => {0 or 1 (top), value} |
+| `asset_params_get i` | read from asset A params field X (imm arg) => {0 or 1 (top), value} |
 
 # Assembler Syntax
 
@@ -384,12 +437,13 @@ A '[proto-buf style variable length unsigned int](https://developers.google.com/
 
 # What TEAL Cannot Do
 
-Current design and implementation limitations to be aware of.
+Design and implementation limitations to be aware of with various versions of TEAL.
 
 * TEAL cannot create or change a transaction, only approve or reject.
 * Stateless TEAL cannot lookup balances of Algos or other assets. (Standard transaction accounting will apply after TEAL has run and authorized a transaction. A TEAL-approved transaction could still be invalid by other accounting rules just as a standard signed transaction could be invalid. e.g. I can't give away money I don't have.)
 * TEAL cannot access information in previous blocks. TEAL cannot access most information in other transactions in the current block. (TEAL can access fields of the transaction it is attached to and the transactions in an atomic transaction group.)
 * TEAL cannot know exactly what round the current transaction will commit in (but it is somewhere in FirstValid through LastValid).
 * TEAL cannot know exactly what time its transaction is committed.
-* TEAL cannot loop. Its branch instructions `bnz` "branch if not zero", `bz` "branch if zero" and `b` "branch" can only branch forward so as to skip some code.
-* TEAL cannot recurse. There is no subroutine jump operation.
+* TEAL cannot loop prior to v4. In v3 and prior, the branch instructions `bnz` "branch if not zero", `bz` "branch if zero" and `b` "branch" can only branch forward so as to skip some code.
+* Until v4, TEAL had no notion of subroutines (and therefore no recursion). As of v4, use `callsub` and `retsub`.
+* TEAL cannot make indirect jumps. `b`, `bz`, `bnz`, and `callsub` jump to an immediately specified address, and `retsub` jumps to the address currently on the top of the call stack, which is manipulated only by previous calls to `callsub`.


### PR DESCRIPTION
This PR regenerates documentation from source for both the `go-algorand` and `indexer` repos at their latest versions.