### PR TITLE
Add note about alphabetic sorting

### DIFF
--- a/docs/reference/transactions.md
+++ b/docs/reference/transactions.md
@@ -2,6 +2,8 @@ title: Transaction Reference
 
 Each table below specifies the **field name**, whether it is optional or required, its **type** within the protocol code (note that SDKs input types for these fields may differ), the **codec**, which is the name of the field when viewed within a transaction, and a **description** of the field. 
 
+**Important**: When signing, the fields have to be sorted alphabetically to match the Algorand canonical encoding.
+
 # Common Fields (`Header` and `Type`)
 These fields are common to all transactions.
 


### PR DESCRIPTION
If the fields are not alphabetically sorted, the signature validation fails (unless signing with KMD). The comment is from the [Java SDK]( https://github.com/algorand/java-algorand-sdk/blob/e9871a544ad6155df8cb67f5d95ea38254f8a6a7/src/main/java/com/algorand/algosdk/util/Encoder.java#L26)