### PR TITLE
Smart Contracts section typo edits

### DIFF
--- a/docs/features/asc1/stateful/hello_world.md
+++ b/docs/features/asc1/stateful/hello_world.md
@@ -104,7 +104,8 @@ load 0
 return
 ```
 
-!!! warning The above approval program is **insecure** and should **not** be used in a real application. In particular, anybody can update the approval program. For a real application, we recommend starting from the template provided in the [Overview](./index.md#boilerplate-stateful-smart-contract).
+!!! warning 
+  The above approval program is **insecure** and should **not** be used in a real application. In     particular, anybody can update the approval program. For a real application, we recommend starting from the template provided in the [Overview](./index.md#boilerplate-stateful-smart-contract).
 
 #### Define TEAL Version
 

--- a/docs/features/asc1/stateful/hello_world.md
+++ b/docs/features/asc1/stateful/hello_world.md
@@ -104,8 +104,8 @@ load 0
 return
 ```
 
-!!! warning 
-  The above approval program is **insecure** and should **not** be used in a real application. In     particular, anybody can update the approval program. For a real application, we recommend starting from the template provided in the [Overview](./index.md#boilerplate-stateful-smart-contract).
+!!! Warning
+    The above approval program is **insecure** and should **not** be used in a real application. In particular, anybody can update the approval program. For a real application, we recommend starting from the template provided in the [Overview](./index.md#boilerplate-stateful-smart-contract).
 
 #### Define TEAL Version
 

--- a/docs/features/asc1/stateless/sdks.md
+++ b/docs/features/asc1/stateless/sdks.md
@@ -206,7 +206,7 @@ func main() {
 // Result = ASABACI=
 ```
 
-Once a TEAL program is compiled, the bytes of the program can be used as a parameter to the LogigSig method. Most of the SDKs support the bytes encoded in base64 or hexadecimal format. 
+Once a TEAL program is compiled, the bytes of the program can be used as a parameter to the LogicSig method. Most of the SDKs support the bytes encoded in base64 or hexadecimal format. 
 
 The binary bytes are used in the SDKs as shown below. If using the `goal` command-line tool to compile the TEAL code, these same bytes can be retrieved using the following commands. 
 


### PR DESCRIPTION
- Warning box incorrectly formatted and did not show up properly.
- fixed typo