### PR TITLE
Fixed typos, errors, improved hardcoded code samples on stateful smart contract documentation

### DIFF
--- a/docs/features/asc1/stateful/hello_world.md
+++ b/docs/features/asc1/stateful/hello_world.md
@@ -104,7 +104,8 @@ load 0
 return
 ```
 
-!!! warning The above approval program is **insecure** and should **not** be used in a real application. In particular, anybody can update the approval program. For a real application, we recommend starting from the template provided in the [Overview](./index.md#boilerplate-stateful-smart-contract).
+!!! warning 
+  The above approval program is **insecure** and should **not** be used in a real application. In     particular, anybody can update the approval program. For a real application, we recommend starting from the template provided in the [Overview](./index.md#boilerplate-stateful-smart-contract).
 
 #### Define TEAL Version
 

--- a/docs/features/asc1/stateful/hello_world.md
+++ b/docs/features/asc1/stateful/hello_world.md
@@ -104,8 +104,8 @@ load 0
 return
 ```
 
-!!! warning 
-  The above approval program is **insecure** and should **not** be used in a real application. In     particular, anybody can update the approval program. For a real application, we recommend starting from the template provided in the [Overview](./index.md#boilerplate-stateful-smart-contract).
+!!! Warning
+    The above approval program is **insecure** and should **not** be used in a real application. In particular, anybody can update the approval program. For a real application, we recommend starting from the template provided in the [Overview](./index.md#boilerplate-stateful-smart-contract).
 
 #### Define TEAL Version
 

--- a/docs/features/asc1/stateful/sdks.md
+++ b/docs/features/asc1/stateful/sdks.md
@@ -1004,6 +1004,9 @@ fmt.Printf("Cleared local state for app-id: %d\n", confirmedTxn.Transaction.Txn.
 
 # Appendix
 
+!!! Notice
+    The below example codes are hardcoded with an address. To run the below code, replace the hardcoded account addresses to your account address.
+
 ## Approval Program Walkthrough
 
 ```teal
@@ -1043,7 +1046,7 @@ err
 handle_noop:
 // Handle NoOp
 // Check for creator
-addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4
+addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4 //replace with your account address
 txn Sender
 ==
 bnz handle_optin
@@ -1098,14 +1101,14 @@ return
 
 handle_deleteapp:
 // Check for creator
-addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4
+addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4 //replace with your account address
 txn Sender
 ==
 return
 
 handle_updateapp:
 // Check for creator
-addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4
+addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4 //replace with your account address
 txn Sender
 ==
 return
@@ -1152,7 +1155,7 @@ err
 handle_noop:
 // Handle NoOp
 // Check for creator
-addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4
+addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4 //replace with your account address
 txn Sender
 ==
 bnz handle_optin
@@ -1214,14 +1217,14 @@ return
 
 handle_deleteapp:
 // Check for creator
-addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4
+addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4 //replace with your account address
 txn Sender
 ==
 return
 
 handle_updateapp:
 // Check for creator
-addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4
+addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4 //replace with your account address
 txn Sender
 ==
 return

--- a/docs/features/asc1/stateless/sdks.md
+++ b/docs/features/asc1/stateless/sdks.md
@@ -206,7 +206,7 @@ func main() {
 // Result = ASABACI=
 ```
 
-Once a TEAL program is compiled, the bytes of the program can be used as a parameter to the LogigSig method. Most of the SDKs support the bytes encoded in base64 or hexadecimal format. 
+Once a TEAL program is compiled, the bytes of the program can be used as a parameter to the LogicSig method. Most of the SDKs support the bytes encoded in base64 or hexadecimal format. 
 
 The binary bytes are used in the SDKs as shown below. If using the `goal` command-line tool to compile the TEAL code, these same bytes can be retrieved using the following commands. 
 

--- a/examples/smart_contracts/v2/python/stateful_smart_contracts.py
+++ b/examples/smart_contracts/v2/python/stateful_smart_contracts.py
@@ -58,7 +58,7 @@ err
 handle_noop:
 // Handle NoOp
 // Check for creator
-addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4
+addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4 //replace with your account address
 txn Sender
 ==
 bnz handle_optin
@@ -113,14 +113,14 @@ return
 
 handle_deleteapp:
 // Check for creator
-addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4
+addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4 //replace with your account address
 txn Sender
 ==
 return
 
 handle_updateapp:
 // Check for creator
-addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4
+addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4 //replace with your account address
 txn Sender
 ==
 return
@@ -164,7 +164,7 @@ err
 handle_noop:
 // Handle NoOp
 // Check for creator
-addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4
+addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4 //replace with your account address
 txn Sender
 ==
 bnz handle_optin
@@ -226,14 +226,14 @@ return
 
 handle_deleteapp:
 // Check for creator
-addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4
+addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4 //replace with your account address
 txn Sender
 ==
 return
 
 handle_updateapp:
 // Check for creator
-addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4
+addr 5XWY6RBNYHCSY2HK5HCTO62DUJJ4PT3G4L77FQEBUKE6ZYRGQAFTLZSQQ4 //replace with your account address
 txn Sender
 ==
 return


### PR DESCRIPTION
- refactored the warning message to make it show up properly
- fixed typos
- added comments and notice about hardcoded account addresses in the TEAL code to improve learning experience.