### PR TITLE
Update sandbox copy to sandbox copyTo

### DIFF
--- a/docs/build-apps/setup.md
+++ b/docs/build-apps/setup.md
@@ -80,7 +80,7 @@ This method is recommended if you need access to all developer tools including `
 !!! Info
 	When using sandbox, `goal` should be replaced by `./sandbox goal`. Furthermore, `./sandbox goal` runs in its own Docker container and cannot directly access files in the current folder. To run any `goal` command that uses files in the current folder, you need to first copy the files. For example, to send the transactions in the file `mytransaction.sig`, you need to run:
 	```bash
-	./sandbox copy mytransaction.sig
+	./sandbox copyTo mytransaction.sig
 	./sandbox goal clerk rawsend -f mytransaction.sig
 	```
 	instead of:

--- a/docs/features/asc1/stateful/hello_world.md
+++ b/docs/features/asc1/stateful/hello_world.md
@@ -184,8 +184,8 @@ goal app create --creator $ADDR_CREATOR \
 !!! Note
 	If you are using [sandbox](https://github.com/algorand/sandbox), you need to copy the approval and clear programs to sandbox beforehand. Concretely, after all the `export` commands, run:
     ```bash
-    ./sandbox copy "$TEAL_APPROVAL_PROG"
-    ./sandbox copy "$TEAL_CLEAR_PROG"
+    ./sandbox copyTo "$TEAL_APPROVAL_PROG"
+    ./sandbox copyTo "$TEAL_CLEAR_PROG"
     ./sandbox goal app create ...
     ```
     where `...` should be replaced by the parameters above.


### PR DESCRIPTION
sandbox renamed the `sandbox copy` command
into `sandbox copyTo`

This commit is meant to propagate the change
to the documentation.