### PR TITLE
Update Betanet to v2.9.0-beta

### DIFF
--- a/docs/reference/algorand-networks/betanet.md
+++ b/docs/reference/algorand-networks/betanet.md
@@ -12,10 +12,10 @@ Visit the new docs to get started:
 🔷 = BetaNet availability only
 
 # Version
-`v2.8.0-beta`
+`v2.9.0-beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.8.0-beta
+https://github.com/algorand/go-algorand/releases/tag/v2.9.0-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
Betanet was updated at 10:30AM ET (2:30PM UTC) today Wed Aug 4.