### PR TITLE
Devops/v2.9.1 stable

### DIFF
--- a/docs/reference/algorand-networks/mainnet.md
+++ b/docs/reference/algorand-networks/mainnet.md
@@ -7,10 +7,10 @@ title: MainNet
 - [Fast Catchup](../../../run-a-node/setup/install/#sync-node-network-using-fast-catchup)
   
 # Version
-`v2.8.0.stable`
+`v2.9.1.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.8.0-stable
+https://github.com/algorand/go-algorand/releases/tag/v2.9.1-stable
 
 # Genesis ID
 `mainnet-v1.0`

--- a/docs/reference/algorand-networks/testnet.md
+++ b/docs/reference/algorand-networks/testnet.md
@@ -7,10 +7,10 @@ title: TestNet
 - [Fast Catchup](../../../run-a-node/setup/install/#sync-node-network-using-fast-catchup)
   
 # Version
-`v2.8.0.stable`
+`v2.9.1.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.8.0-stable
+https://github.com/algorand/go-algorand/releases/tag/v2.9.1-stable
 
 # Genesis ID
 `testnet-v1.0`


### PR DESCRIPTION
Testnet and Mainnet updated to v2.9.1 stable on Thu Aug 12th, 10:30AM ET (2:30PM UTC).