### PR TITLE
Fix wrong amount in txn description

### DIFF
--- a/docs/features/transactions/signatures.md
+++ b/docs/features/transactions/signatures.md
@@ -33,7 +33,7 @@ This is an example of a transaction signed by an Algorand private key displayed 
   }
 }
 ```
-This transaction sends 1 Algo from `"EW64GC..."` to `"QC7XT7..."` on TestNet. The transaction was signed with the private key that corresponds to the `"snd"` address of `"EW64GC..."`. The base64 encoded signature is shown as the value of the [`"sig"`](../../reference/transactions.md#sig) field.
+This transaction sends 10 Algo from `"EW64GC..."` to `"QC7XT7..."` on TestNet. The transaction was signed with the private key that corresponds to the `"snd"` address of `"EW64GC..."`. The base64 encoded signature is shown as the value of the [`"sig"`](../../reference/transactions.md#sig) field.
 
 **Related How-To**
 


### PR DESCRIPTION
I'm pretty sure amt=10.000.000 corresponds to 10 ALGO, that would also fit the example(s) in https://developer.algorand.org/docs/features/transactions/#send-5-algos.