### PR TITLE
Update for 2.10.1-beta

### DIFF
--- a/docs/reference/algorand-networks/betanet.md
+++ b/docs/reference/algorand-networks/betanet.md
@@ -12,10 +12,10 @@ Visit the new docs to get started:
 🔷 = BetaNet availability only
 
 # Version
-`v2.10.0-beta`
+`v2.10.1-beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.10.0-beta
+https://github.com/algorand/go-algorand/releases/tag/v2.10.1-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
BetaNet was upgraded to version 2.10.1, Thu Aug 26, 2021, 10:30AM ET (2:30PM UTC).  This release does not contain a consensus upgrade.