### PR TITLE
Fix URL to indexer/#search-assets in Retrieve Assets Information section

### DIFF
--- a/docs/features/asa.md
+++ b/docs/features/asa.md
@@ -1235,7 +1235,7 @@ goal asset destroy --creator <creator-address> --manager <asset-manager-address>
 Retrieve an asset's configuration information from the network using the SDKs or `goal`. Additional details are also added to the accounts that own the specific asset and can be listed with standard account information calls.
 
 !!! info
-    The code below illustrates getting asset information without the Indexer. If you have the Indexer installed use the Indexer API to [search for asset](../features/indexer/#search-assets) information.
+    The code below illustrates getting asset information without the Indexer. If you have the Indexer installed use the Indexer API to [search for asset](../indexer/#search-assets) information.
 
 ``` javascript tab="JavaScript"
 // Function used to print created asset for account and assetid


### PR DESCRIPTION
Currently this link navigates to https://developer.algorand.org/docs/features/features/indexer/#search-assets which 404s (notice the extra "features" in the url.)

I have not tested this because I am not sure how.