### PR TITLE
Update Betanet to 3.0.0

### DIFF
--- a/docs/reference/algorand-networks/betanet.md
+++ b/docs/reference/algorand-networks/betanet.md
@@ -12,10 +12,10 @@ Visit the new docs to get started:
 🔷 = BetaNet availability only
 
 # Version
-`v2.10.1-beta`
+`v3.0.0-beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v2.10.1-beta
+https://github.com/algorand/go-algorand/releases/tag/v3.0.0-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
BetaNet upgraded to version 3.0.0 today, Wed Sept 15, 2021 2:30PM ET (6:30PM UTC). This release does contain a consensus upgrade.