### PR TITLE
renamed stateless smart contracts to smartsigs

### DIFF
--- a/docs/get-details/dapps/smart-contracts/smartsigs/walkthrough.md
+++ b/docs/get-details/dapps/smart-contracts/smartsigs/walkthrough.md
@@ -156,4 +156,4 @@ $ python3 -c "import base64;print(base64.b64encode((123).to_bytes(8,'big')).deco
 
 The example above converts the integer value of 123 to a base64 encoded string. TEAL currently does not support negative numbers. 
 
-Each SDK provides facilities for passing parameters as well. These processes are described in the [Interact with smart signatures](../frontend/stateless-sdks) Usage documentation.
+Each SDK provides facilities for passing parameters as well. These processes are described in the [Interact with smart signatures](../frontend/smartsigs) Usage documentation.


### PR DESCRIPTION
Broken link was corrected. Link changed as stateless smart contracts were renamed smartsigs in AVM release 1.0