### PR TITLE
Added note to REST API section explaining endpoint

### DIFF
--- a/docs/rest-apis/algod/v2.md
+++ b/docs/rest-apis/algod/v2.md
@@ -1,7 +1,8 @@
 title: v2
 ---
 
-The endpoint for the REST API is defined by the `EndpointAddress` property in the [Node Configuration Settings](https://developer.algorand.org/docs/run-a-node/reference/config/). By default, the host is set to `127.0.0.1` and the port is `8080` (or chosen randomly if `8080` is not available).
+!!! info
+    If you are running your own node, you can configure the endpoint for the REST API in the [Node Configuration Settings](https://developer.algorand.org/docs/run-a-node/reference/config/) by changing the `EndpointAddress` property. By default, the host is set to `127.0.0.1` and the port is `8080` (or chosen randomly if `8080` is not available).
 
 <a name="paths"></a>
 ## Paths


### PR DESCRIPTION
### Observation
The first thing I wanted to do after installing the node was to query the REST API. But I couldn't find in the docs where the default endpoint is defined. I didn't think to look under "Node Reference -> Node config settings" because I was looking for *default* behavior.

### Suggestion
I added a note to the [algod v2 page](https://developer.algorand.org/docs/rest-apis/algod/v2/) explaining what the default host+port is, and where to change this setting. 
![image](https://user-images.githubusercontent.com/39585474/136941990-b9f4e352-debf-4d28-8408-2399f67393fe.png)
