### PR TITLE
adding directions for auction app sandbox

### DIFF
--- a/docs/get-started/dapps/pyteal.md
+++ b/docs/get-started/dapps/pyteal.md
@@ -34,6 +34,9 @@ cd auction-demo
  
 This will clone down the [sandbox](https://github.com/algorand/sandbox) repository to `./_sandbox` and start some docker containers. 
 
+!!!note
+The following command will default to the `release` configuration. Other configurations that are compatible with this demo are `beta, `nightly` and `dev`. This is because the app requires an unencrypted-default-wallet to sign transactions.
+
 ```bash
 ./sandbox up
 ```


### PR DESCRIPTION
Since the auction app now includes a sandbox shell script, changing the directions to use that instead of cloning down the sandbox separately.