### PR TITLE
Existing importlib-metadata is too old and causes mkdocs builds to fail

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs-material==7.1.8
 mkdocs-awesome-pages-plugin==2.5.0
+importlib-metadata>=3.10


### PR DESCRIPTION
Multiple PRs can't be built as mkdocs requirements is a newer importlib-metadata package.