### PR TITLE
Global.LatestTimestamp is NOT available in LogicSig contracts

### DIFF
--- a/docs/get-details/dapps/avm/teal/opcodes.md
+++ b/docs/get-details/dapps/avm/teal/opcodes.md
@@ -519,7 +519,7 @@ FirstValidTime causes the program to fail. The field is reserved for future use.
 | 4 | GroupSize | uint64 | Number of transactions in this atomic transaction group. At least 1 |
 | 5 | LogicSigVersion | uint64 | Maximum supported TEAL version. LogicSigVersion >= 2. |
 | 6 | Round | uint64 | Current round number. LogicSigVersion >= 2. |
-| 7 | LatestTimestamp | uint64 | Last confirmed block UNIX timestamp. Fails if negative. LogicSigVersion >= 2. |
+| 7 | LatestTimestamp | uint64 | Last confirmed block UNIX timestamp. Fails if negative. Unavailabe in any LogicSig. |
 | 8 | CurrentApplicationID | uint64 | ID of current application executing. Fails in LogicSigs. LogicSigVersion >= 2. |
 | 9 | CreatorAddress | []byte | Address of the creator of the current application. Fails if no such application is executing. LogicSigVersion >= 3. |
 | 10 | CurrentApplicationAddress | []byte | Address that the current application controls. Fails in LogicSigs. LogicSigVersion >= 5. |


### PR DESCRIPTION
Any contract attempting to use Global.LatestTimestamp opCode will receive the following error from the network node with a 400 status:
```
global[7] not allowed in current mode
```