### PR TITLE
Remove extra parenthesis in Python SDK example

### DIFF
--- a/docs/sdks/python/index.md
+++ b/docs/sdks/python/index.md
@@ -232,7 +232,7 @@ def first_transaction_example(private_key, my_address):
 	unsigned_txn = PaymentTxn(my_address, params, receiver, 1000000, None, note)
 
 	# sign transaction
-	signed_txn = unsigned_txn.sign(private_key))
+	signed_txn = unsigned_txn.sign(private_key)
 
     # submit transaction
 	txid = algod_client.send_transaction(signed_txn)


### PR DESCRIPTION
This causes a syntax error if the code is ran