### PR TITLE
Devops/v3.2.1.stable

### DIFF
--- a/docs/get-details/algorand-networks/mainnet.md
+++ b/docs/get-details/algorand-networks/mainnet.md
@@ -1,10 +1,10 @@
 title: MainNet
   
 # Version
-`v3.0.1.stable`
+`v3.2.1.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v3.0.1-stable
+https://github.com/algorand/go-algorand/releases/tag/v3.2.1-stable
 
 # Genesis ID
 `mainnet-v1.0`

--- a/docs/get-details/algorand-networks/testnet.md
+++ b/docs/get-details/algorand-networks/testnet.md
@@ -1,10 +1,10 @@
 title: TestNet
   
 # Version
-`v3.0.1.stable`
+`v3.2.1.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v3.0.1-stable
+https://github.com/algorand/go-algorand/releases/tag/v3.2.1-stable
 
 # Genesis ID
 `testnet-v1.0`


### PR DESCRIPTION
MainNet and TestNet have been updated to 3.2.1 today, Wed Dec 8, 2021 10:00AM EST (3:30PM UTC). This release does not contain a consensus upgrade.

** FYI for anyone with auto-update, we recently renewed our gpg keys, so please find our new public key here: https://releases.algorand.com/key.pub **
https://forum.algorand.org/t/testnet-and-mainnet-update-3-2-1/5352