### PR TITLE
Update betanet.md (go-algorand 3.2.2-beta release)

### DIFF
--- a/docs/get-details/algorand-networks/betanet.md
+++ b/docs/get-details/algorand-networks/betanet.md
@@ -4,10 +4,10 @@ title: BetaNet 🔷
 🔷 = BetaNet availability only
 
 # Version
-`v3.2.1-beta`
+`v3.2.2-beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v3.2.1-beta
+https://github.com/algorand/go-algorand/releases/tag/v3.2.2-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
BetaNet was upgraded to version 3.2.2, Mon Dec 13, 2021, 11:30AM ET (4:30PM UTC).  This release does not contain a consensus upgrade.