### PR TITLE
Devops/v3.2.2 stable

### DIFF
--- a/docs/get-details/algorand-networks/mainnet.md
+++ b/docs/get-details/algorand-networks/mainnet.md
@@ -1,10 +1,10 @@
 title: MainNet
   
 # Version
-`v3.0.1.stable`
+`v3.2.2.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v3.0.1-stable
+https://github.com/algorand/go-algorand/releases/tag/v3.2.2-stable
 
 # Genesis ID
 `mainnet-v1.0`

--- a/docs/get-details/algorand-networks/testnet.md
+++ b/docs/get-details/algorand-networks/testnet.md
@@ -1,10 +1,10 @@
 title: TestNet
   
 # Version
-`v3.0.1.stable`
+`v3.2.2.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v3.0.1-stable
+https://github.com/algorand/go-algorand/releases/tag/v3.2.2-stable
 
 # Genesis ID
 `testnet-v1.0`


### PR DESCRIPTION
Update for 3.2.2 stable release.  Released at 10:40 AM 12/15/2021.