### PR TITLE
Update betanet to version 3.2.3

### DIFF
--- a/docs/get-details/algorand-networks/betanet.md
+++ b/docs/get-details/algorand-networks/betanet.md
@@ -4,10 +4,10 @@ title: BetaNet 🔷
 🔷 = BetaNet availability only
 
 # Version
-`v3.2.2-beta`
+`v3.2.3-beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v3.2.2-beta
+https://github.com/algorand/go-algorand/releases/tag/v3.2.3-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
BetaNet was upgraded to version 3.2.3, Tue Dec 28, 2021, 1:30 PM ET (6:30PM UTC).  This release does not contain a consensus upgrade.