### PR TITLE
Devops/v3.2.3 stable

### DIFF
--- a/docs/get-details/algorand-networks/mainnet.md
+++ b/docs/get-details/algorand-networks/mainnet.md
@@ -1,10 +1,10 @@
 title: MainNet
   
 # Version
-`v3.0.1.stable`
+`v3.2.3.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v3.0.1-stable
+https://github.com/algorand/go-algorand/releases/tag/v3.2.3-stable
 
 # Genesis ID
 `mainnet-v1.0`

--- a/docs/get-details/algorand-networks/testnet.md
+++ b/docs/get-details/algorand-networks/testnet.md
@@ -1,10 +1,10 @@
 title: TestNet
   
 # Version
-`v3.0.1.stable`
+`v3.2.3.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v3.0.1-stable
+https://github.com/algorand/go-algorand/releases/tag/v3.2.3-stable
 
 # Genesis ID
 `testnet-v1.0`


### PR DESCRIPTION
MainNet and TestNet have been updated to 3.2.3 today, Wed Jan 5, 2021 10:30AM EST (3:30PM UTC). **This release does not contain a consensus upgrade.**

Thanks. Please merge this. I will delete the the 3.2.2 PR as it will be stale once this merges. Let us know if we should add others as Reviewers for these PRs as well.