### PR TITLE
Add venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,12 @@ site/
 *~
 *#
 .DS_Store
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/


### PR DESCRIPTION
Adds venv to `.gitignore` in order to avoid versioning virtual environment configuration.

I discovered virtual environments aren't ignored when testing #678, and I offer the PR in case others feel it's a useful addition.  If we prefer to keep as is, then feel welcomed to close the PR.

I sourced the change from https://github.com/algorand/pyteal/blob/master/.gitignore.

