### PR TITLE
Update Betanet to v3.3.0-beta

### DIFF
--- a/docs/get-details/algorand-networks/betanet.md
+++ b/docs/get-details/algorand-networks/betanet.md
@@ -4,10 +4,10 @@ title: BetaNet 🔷
 🔷 = BetaNet availability only
 
 # Version
-`v3.2.3-beta`
+`v3.3.0-beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v3.2.3-beta
+https://github.com/algorand/go-algorand/releases/tag/v3.3.0-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
BetaNet updated to version 3.3.0 today, Fri Jan 21, 2022, 10:45 AM EST (3:45 PM UTC). This release does not contain a consensus upgrade.