### PR TITLE
Improve Python global state reading

### DIFF
--- a/docs/get-details/dapps/smart-contracts/frontend/apps.md
+++ b/docs/get-details/dapps/smart-contracts/frontend/apps.md
@@ -648,12 +648,10 @@ Anyone may read the [global state](../apps/#reading-global-state-from-other-smar
                 print(f"local_state of account {addr} for app_id {app_id}: ", local_state['key-value'])
 
     # read app global state
-    def read_global_state(client, addr, app_id) :   
-        results = client.account_info(addr)
-        apps_created = results['created-apps']
-        for app in apps_created :
-            if app['id'] == app_id :
-                print(f"global_state for app_id {app_id}: ", app['params']['global-state'])
+    def read_global_state(client, app_id):
+        app = client.application_info(app_id)
+        global_state = app['params']['global-state'] if "global-state" in app["params"] else []
+        print(f"global_state for app_id {app_id}: ", global_state)
     ```
 
 === "JavaScript"


### PR DESCRIPTION
The current code went over each application the creator created.
This can be slow if many applications are created.
In addition, this requires knowing the creator address.

I modified the code to directly get the global state from the application endpoint.

I also added a test to avoid crashing if the global state is empty:
https://forum.algorand.org/t/fetching-global-state-via-pythonsdk/3377/4?u=fabrice

Before merging this PR, ideally:
* check `read_global_state` is not used anywhere else and fix the calls if needed
* make the same changes to the other languages