### PR TITLE
Update requirements for Python 3.10 compatability.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs-material==7.1.8
-mkdocs-awesome-pages-plugin==2.5.0
-importlib-metadata>=3.10
+mkdocs-material==8.1.9
+mkdocs-awesome-pages-plugin==2.6.1
+importlib-metadata==4.10.1


### PR DESCRIPTION
I've not been able to test backwards compatibility with older versions of Python, 3.9 or below.