### PR TITLE
Document clear state program constraints with inner transactions

### DIFF
--- a/docs/get-details/dapps/smart-contracts/apps/index.md
+++ b/docs/get-details/dapps/smart-contracts/apps/index.md
@@ -91,6 +91,9 @@ In this example, the type is set to pay using the TypeEnum field, the amount is 
 !!!note
     Inner transactions also have access to the Sender field. It is not required to set this field as all inner transactions default the sender to the contract address. If another account is rekeyed to the smart contract address, setting sender to the address that has been rekeyed allows the contract to spend from that account. The recipient of an inner transaction must be in the accounts array. Additionally, if the sender of an inner transaction is not the contract, the sender must also be in the accounts array.
 
+!!!note
+    Clear state programs do _not_ support creating inner transactions.  However, clear state programs _can_ be called by an inner transaction.
+
 ## Asset transfer
 If a smart contract wishes to transfer an asset it holds or needs to opt into an asset this can be done with an asset transfer inner transaction.
 
@@ -269,7 +272,7 @@ itxn_submit
 All inner transactions will be stored as inner transactions within the outer application transaction. These can be accessed by getting the transaction id as normal and looking for the `inner-txns` header in the response.
 
 ## Allowed transaction properties
-Since TEAL 6 all application types can be used within inner transactions. If you're using TEAL 5 you will only be able to make payment and asset transfer transactions, with some properties such as `RekeyTo` not being allowed.
+Since TEAL 6, all transaction types can be used within inner transactions. If you're using TEAL 5 you will only be able to make payment and asset transfer transactions, with some properties such as `RekeyTo` not being allowed.
 
 # Modifying state in smart contract
 Smart contracts can create, update, and delete values in global or local state. The number of values that can be written is limited based on how the contract was first created. See [Creating the Smart Contract](#creating-the-smart-contract) for details on configuring the initial global and local storage. State is represented with key-value pairs. The key is limited to 64 bytes. The key plus the value is limited to 128 bytes total. Using smaller keys to have more storage available for the value is possible. The keys are stored as byte slices (byte-array value) and the values are stored as either byte slices (byte-array value) or uint64s. The TEAL language provides several opcodes for facilitating reading and writing to state.


### PR DESCRIPTION
Documents clear state program constraints when interacting with inner transactions.

Relates to https://github.com/algorand/go-algorand/pull/3556.