### PR TITLE
add transaction

### DIFF
--- a/docs/get-details/dapps/smart-contracts/frontend/apps.md
+++ b/docs/get-details/dapps/smart-contracts/frontend/apps.md
@@ -91,6 +91,8 @@ The example application defined below may hold up to one each of `bytes` and `in
 
 === "Python"
 	```python
+    from algosdk.future import transaction
+
     # declare application state storage (immutable)
     local_ints = 1
     local_bytes = 1


### PR DESCRIPTION
Specify that transaction is from `algosdk.future` not `algosdk`

sync with https://github.com/algorand/docs/blob/master/examples/smart_contracts/v2/python/stateful_smart_contracts.py
currently from https://github.com/algorand/docs/blob/28f35f44e158b89ad5128f8b3a12b667e528f8bb/examples/smart_contracts/v2/python/stateful_smart_contracts.py#L4