### PR TITLE
Mkdocs config: point edit page button to staging & group top-level sections

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,11 +1,13 @@
 site_name: Algorand Developer Docs
 
-theme: 
-    name: material
-    font: Lato
-    palette:
-      primary: '#000000'
-      accent: '#5662DB'
+theme:
+  name: material
+  font: Lato
+  palette:
+    primary: "#000000"
+    accent: "#5662DB"
+  icon:
+    repo: fontawesome/brands/github
 
 markdown_extensions:
   - admonition
@@ -36,3 +38,7 @@ markdown_extensions:
 plugins:
   - search
   - awesome-pages
+
+repo_name: algorand/docs
+repo_url: https://github.com/algorand/docs
+edit_uri: edit/staging/docs/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,8 @@ theme:
     accent: "#5662DB"
   icon:
     repo: fontawesome/brands/github
+  features:
+    - navigation.sections
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
#### Before
![image](https://user-images.githubusercontent.com/13184582/153376100-2db905f4-1d12-4fc0-b003-55a4d74dc402.png)
Edit button on the site points to https://github.com/algorand/docs/edit/master/docs/index.md
(Button only seen on official site, not locally with `mkdocs serve`)

#### After
![image](https://user-images.githubusercontent.com/13184582/153375966-16d1568a-67cd-4155-9c54-711665580177.png)
Edit button points to https://github.com/algorand/docs/edit/staging/docs/index.md