### PR TITLE
Update stale reference to inner transaction limit

### DIFF
--- a/docs/get-details/dapps/avm/teal/opcodes.md
+++ b/docs/get-details/dapps/avm/teal/opcodes.md
@@ -1318,7 +1318,7 @@ bitlen interprets arrays as big-endian integers, unlike setbit/getbit
 - Opcode: 0xb3
 - Pops: _None_
 - Pushes: _None_
-- Execute the current inner transaction. Fail if 16 inner transactions have already been executed, or if the transaction itself fails.
+- Execute the current inner transaction. Fail if 256 inner transactions have already been executed, or if the transaction itself fails.
 - LogicSigVersion >= 5
 - Mode: Application
 


### PR DESCRIPTION
Updates the only reference I found to a stale inner transaction limit.  TEAL 6 supports 256 inner transactions.

Thanks to @barnjamin for catching the issue in https://github.com/algorand/pyteal/pull/193#discussion_r805942831.  His comment prompted my _docs_ review.