### PR TITLE
go-algorand 3.4.0 beta

### DIFF
--- a/docs/get-details/algorand-networks/betanet.md
+++ b/docs/get-details/algorand-networks/betanet.md
@@ -4,10 +4,10 @@ title: BetaNet 🔷
 🔷 = BetaNet availability only
 
 # Version
-`v3.3.0-beta`
+`v3.4.0-beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v3.3.0-beta
+https://github.com/algorand/go-algorand/releases/tag/v3.4.0-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
BetaNet was upgraded to version 3.4.0, Wed Feb 16, 2022, 10:30AM ET (3:30PM UTC).  This release DOES contain a consensus upgrade.