### PR TITLE
Fix typo on transaction example

### DIFF
--- a/docs/sdks/javascript/index.md
+++ b/docs/sdks/javascript/index.md
@@ -161,7 +161,7 @@ To interact with the Algorand blockchain, you can send different types of transa
             from: sender, 
             to: receiver, 
             amount: amount, 
-            node: note, 
+            note: note, 
             suggestedParams: params
         });
 ```


### PR DESCRIPTION
makePaymentTxnWithSuggestedParamsFromObject configuration object is referring to `node` instead of `note` in the **transaction note** property.