### PR TITLE
Fix typo in algod REST API docs

### DIFF
--- a/docs/rest-apis/algod/v2.md
+++ b/docs/rest-apis/algod/v2.md
@@ -841,7 +841,7 @@ POST /v2/teal/compile
 
 
 **Description**
-Given TEAL source code in plain text, return base64 encoded program bytes and base32 SHA512_256 hash of program bytes (Address style). This endpoint is only enabled when a node's configureation file sets EnableDeveloperAPI to true.
+Given TEAL source code in plain text, return base64 encoded program bytes and base32 SHA512_256 hash of program bytes (Address style). This endpoint is only enabled when a node's configuration file sets EnableDeveloperAPI to true.
 
 
 **Parameters**
@@ -890,7 +890,7 @@ POST /v2/teal/dryrun
 
 
 **Description**
-Executes TEAL program(s) in context and returns debugging information about the execution. This endpoint is only enabled when a node's configureation file sets EnableDeveloperAPI to true.
+Executes TEAL program(s) in context and returns debugging information about the execution. This endpoint is only enabled when a node's configuration file sets EnableDeveloperAPI to true.
 
 
 **Parameters**


### PR DESCRIPTION
Fixes a typo observed while reading docs.  Change made via `find docs -type f -exec sed -i '' 's/configureation/configuration/g' {} \;`.