### PR TITLE
fixing broken link

### DIFF
--- a/docs/get-details/transactions/index.md
+++ b/docs/get-details/transactions/index.md
@@ -715,11 +715,11 @@ The Algorand protocol supports pooled fees, where one transaction can pay the fe
 
 For atomic transactions, the fees set on all transactions in the group are summed. This sum is compared against the protocol determined expected fee for the group and may proceed as long as the sum of the fees is at least the required fee for the group.
 
-<center>![Atomic Pooled Fees](/docs/imgs/atomic_transfers-2.png)</center>
+<center>![Atomic Pooled Fees](../../imgs/atomic_transfers-2.png)</center>
 <center>*Atomic Pooled Fees*</center>
 
 !!! note
-    [Inner transactions](/get-details/dapps/smart-contracts/apps/#inner-transactions) may have their fees covered by the outer transactions but they may not cover outer transaction fees. This limitation that only outer transactions may cover the inner transactions is true in the case of nested inner transactions as well.
+    [Inner transactions](../dapps/smart-contracts/apps/#inner-transactions) may have their fees covered by the outer transactions but they may not cover outer transaction fees. This limitation that only outer transactions may cover the inner transactions is true in the case of nested inner transactions as well.
 
 !!! info
     Full running code examples for each SDK and both API versions are available within the GitHub repo at [/examples/atomic_transfers](https://github.com/algorand/docs/tree/master/examples/atomic_transfers) and for [download](https://github.com/algorand/docs/blob/master/examples/atomic_transfers/atomic_transfers.zip?raw=true) (.zip).


### PR DESCRIPTION
Use relative links since the docs prefix in the url path is screwy vs local