### PR TITLE
Update betanet.md for 3.5.1

### DIFF
--- a/docs/get-details/algorand-networks/betanet.md
+++ b/docs/get-details/algorand-networks/betanet.md
@@ -4,10 +4,10 @@ title: BetaNet 🔷
 🔷 = BetaNet availability only
 
 # Version
-`v3.5.0-beta`
+`v3.5.1-beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v3.5.0-beta
+https://github.com/algorand/go-algorand/releases/tag/v3.5.1-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
BetaNet was upgraded to version 3.5.1, Mar 16th, 2022, 10:30AM ET (2:30PM UTC).  This release does not contain a consensus upgrade.