### PR TITLE
Add tealdbg docs

### DIFF
--- a/scripts/reformat-all-commands.sh
+++ b/scripts/reformat-all-commands.sh
@@ -17,6 +17,9 @@ CLI_TOOLS="~/go/bin/" # path to goal, algokey, etc.
 # CLI DIAGCFG
 ./reformat.py -doc-dir ../docs/clis/diagcfg/ -cmd $CLI_TOOLS/diagcfg
 
+# CLI TEALDBG
+./reformat.py -doc-dir ../docs/clis/tealdbg/ -cmd $CLI_TOOLS/tealdbg
+
 # CLI INDEXER
 ./reformat.py -doc-dir ../docs/clis/indexer/ -cmd $CLI_TOOLS/algorand-indexer
 


### PR DESCRIPTION
DO NOT MERGE UNTIL https://github.com/algorand/go-algorand/pull/3830 HAS BEEN

When generating the CLI documentation for the Developer Portal it was noticed that tealdbg was missing. So much like goal, kmd, and algokey, I've updated the script to include the tealdbg output.