### PR TITLE
AssetCloseTo cannot be supplied with a clawback transaction

### DIFF
--- a/docs/get-details/transactions/transactions.md
+++ b/docs/get-details/transactions/transactions.md
@@ -114,7 +114,6 @@ This is a special form of an Asset Transfer Transaction.
 |<a name="assetamount">AssetAmount</a>|_required_|uint64|`"aamt"`| The amount of the asset to be transferred.|
 |<a name="assetsender">AssetSender</a>|_required_|Address|`"asnd"`| The address from which the funds will be withdrawn.|
 |<a name="assetreceiver">AssetReceiver</a>|_required_|Address|`"arcv"`| The recipient of the asset transfer.|
-|<a name="assetcloseto">AssetCloseTo</a>|_optional_|Address|`"aclose"`|Specify this field to remove the entire asset holding balance from the AssetSender account. It will not remove the asset holding.|
 
 # Asset Freeze Transaction
 Transaction Object Type: `AssetFreezeTx`


### PR DESCRIPTION
As pointed out by @canbolukbas in #800 