### PR TITLE
AssetSender should be Sender for an asset optin

### DIFF
--- a/docs/get-details/transactions/transactions.md
+++ b/docs/get-details/transactions/transactions.md
@@ -97,7 +97,7 @@ This is a special form of an Asset Transfer Transaction.
 |Field|Required|Type|codec| Description|
 |---|---|---|---|---|
 |<a name="xferasset">XferAsset</a>| _required_ |uint64|`"xaid"`|The unique ID of the asset to opt-in to.|
-|<a name="assetsender">AssetSender</a>|_required_|Address|`"asnd"`| The account which is allocating the asset to their account's Asset map.|
+|<a name="sender">Sender</a>|_required_|Address|`"snd"`| The account which is allocating the asset to their account's Asset map.|
 |<a name="assetreceiver">AssetReceiver</a>|_required_|Address|`"arcv"`| The account which is allocating the asset to their account's Asset map.|
 
 # Asset Clawback Transaction 


### PR DESCRIPTION
When opting in to an asset (Asset Accept Transaction) the `snd` field is required rather than the `asnd` field.