### PR TITLE
BetaNet upgraded to version 3.6.2

### DIFF
--- a/docs/get-details/algorand-networks/betanet.md
+++ b/docs/get-details/algorand-networks/betanet.md
@@ -4,10 +4,10 @@ title: BetaNet 🔷
 🔷 = BetaNet availability only
 
 # Version
-`v3.5.1-beta`
+`v3.6.2-beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v3.5.1-beta
+https://github.com/algorand/go-algorand/releases/tag/v3.6.2-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
BetaNet was upgraded to version 3.6.2, Tuesday, May 3rd, 2022, 10:30 AM ET (2:30 PM UTC).  This release does not contain a consensus upgrade.