### PR TITLE
Fix Teal loop example

### DIFF
--- a/docs/get-details/dapps/avm/teal/index.md
+++ b/docs/get-details/dapps/avm/teal/index.md
@@ -78,7 +78,7 @@ dup
 int 10
 <=
 bnz loop
-pop
+// once the loop exits, the last counter value will be left on stack
 ```
 
 Subroutines can be implemented using labels and the `callsub` and `retsub` opcodes. The sample below illustrates a sample subroutine call.

--- a/docs/get-details/dapps/avm/teal/index.md
+++ b/docs/get-details/dapps/avm/teal/index.md
@@ -71,12 +71,14 @@ int 0
 loop:
 int 1
 +
+dup
 // implement loop code
 // ...
 // check upper bound
 int 10
 <=
 bnz loop
+pop
 ```
 
 Subroutines can be implemented using labels and the `callsub` and `retsub` opcodes. The sample below illustrates a sample subroutine call.


### PR DESCRIPTION
Fixed an error in the Teal loop example:
`<=` will pop the counter value, `bnz` will pop the compare value, when the loop runs for a second time, the stack will be empty and yield an underflow error when incrementing the counter.