### PR TITLE
algorand-networks: update betanet version

### DIFF
--- a/docs/get-details/algorand-networks/betanet.md
+++ b/docs/get-details/algorand-networks/betanet.md
@@ -4,10 +4,10 @@ title: BetaNet 🔷
 🔷 = BetaNet availability only
 
 # Version
-`v3.6.2-beta`
+`v3.7.0-beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v3.6.2-beta
+https://github.com/algorand/go-algorand/releases/tag/v3.7.0-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
## what

- updates betanet to version `3.7.0`

## why

- we recently released `3.7.0` 