### PR TITLE
BetaNet was upgraded to version 3.7.2

### DIFF
--- a/docs/get-details/algorand-networks/betanet.md
+++ b/docs/get-details/algorand-networks/betanet.md
@@ -4,10 +4,10 @@ title: BetaNet 🔷
 🔷 = BetaNet availability only
 
 # Version
-`v3.7.1-beta`
+`v3.7.2-beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v3.7.1-beta
+https://github.com/algorand/go-algorand/releases/tag/v3.7.2-beta
 
 # Genesis ID
 `betanet-v1.0`


### PR DESCRIPTION
BetaNet was upgraded to version 3.7.2, Thu June 13, 2022, at 10:30 AM ET (2:30 PM UTC).  This release does not contain a consensus upgrade.