### PR TITLE
run-a-node: reference more recent updater script

### DIFF
--- a/docs/run-a-node/setup/install.md
+++ b/docs/run-a-node/setup/install.md
@@ -184,7 +184,7 @@ cd ~/node
 Download the updater script.
 
 ```
-curl https://raw.githubusercontent.com/algorand/go-algorand-doc/master/downloads/installers/update.sh -O
+curl https://raw.githubusercontent.com/algorand/go-algorand/master/cmd/updater/update.sh -O
 ```
 
 + Ensure that your system knows it's an executable file.
@@ -228,7 +228,7 @@ cd ~/node
 Download the updater script.
 
 ```
-wget https://raw.githubusercontent.com/algorand/go-algorand-doc/master/downloads/installers/update.sh
+wget https://raw.githubusercontent.com/algorand/go-algorand/master/cmd/updater/update.sh
 ```
 
 + Ensure that your system knows it's an executable file.


### PR DESCRIPTION
we should reference a better maintained `update.sh` script

cc: @algojack 