### PR TITLE
Update networks to v3.8.1

### DIFF
--- a/docs/get-details/algorand-networks/betanet.md
+++ b/docs/get-details/algorand-networks/betanet.md
@@ -4,10 +4,10 @@ title: BetaNet 🔷
 🔷 = BetaNet availability only
 
 # Version
-`v3.8.0-beta`
+`v3.8.1-beta`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v3.8.0-beta
+https://github.com/algorand/go-algorand/releases/tag/v3.8.1-beta
 
 # Genesis ID
 `betanet-v1.0`

--- a/docs/get-details/algorand-networks/mainnet.md
+++ b/docs/get-details/algorand-networks/mainnet.md
@@ -1,10 +1,10 @@
 title: MainNet
   
 # Version
-`v3.8.0.stable`
+`v3.8.1.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v3.8.0-stable
+https://github.com/algorand/go-algorand/releases/tag/v3.8.1-stable
 
 # Genesis ID
 `mainnet-v1.0`

--- a/docs/get-details/algorand-networks/testnet.md
+++ b/docs/get-details/algorand-networks/testnet.md
@@ -1,10 +1,10 @@
 title: TestNet
   
 # Version
-`v3.8.0.stable`
+`v3.8.1.stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v3.8.0-stable
+https://github.com/algorand/go-algorand/releases/tag/v3.8.1-stable
 
 # Genesis ID
 `testnet-v1.0`


### PR DESCRIPTION
This is approved to publish immediately, as all networks have been upgraded to this version.