### PR TITLE
issue #731: description for online money and total money added

### DIFF
--- a/docs/rest-apis/algod/v2.md
+++ b/docs/rest-apis/algod/v2.md
@@ -579,8 +579,8 @@ GET /v2/ledger/supply
 |Name|Description|Schema|
 |---|---|---|
 |**current_round**  <br>*required*|Round|integer|
-|**online-money**  <br>*required*|OnlineMoney|integer|
-|**total-money**  <br>*required*|TotalMoney|integer|
+|**online-money**  <br>*required*|Supply of MicroAlgos held by online accounts participating in consensus.|integer|
+|**total-money**  <br>*required*|Total Supply of MicroAlgos minted and circulating in the market.|integer|
 
 
 **Produces**


### PR DESCRIPTION
Fixed #731 

Added description for online money and total money on this page: https://github.com/algorand/docs/blob/d75a8da87f6289f5ea111bf2980b8c2236dcfff9/docs/rest-apis/algod/v2.md#L481-L485