### PR TITLE
Update macos doc

### DIFF
--- a/docs/run-a-node/setup/install.md
+++ b/docs/run-a-node/setup/install.md
@@ -172,7 +172,7 @@ goal node status -d /var/lib/algorand
 # Installation with the updater script
 
 ## Installing on a Mac
-Verified on OSX v12.3.1 (Monterey) and OSX v13.4.1 (Ventura).
+Verified on OSX v12.3.1 (Monterey).
 
 + Create a folder to hold the install package and files.
 

--- a/docs/run-a-node/setup/install.md
+++ b/docs/run-a-node/setup/install.md
@@ -172,7 +172,7 @@ goal node status -d /var/lib/algorand
 # Installation with the updater script
 
 ## Installing on a Mac
-Verified on OSX v10.13.4 (High Sierra) and 10.15.7 (Catalina).
+Verified on OSX v12.3.1 (Monterey) and OSX v13.4.1 (Ventura).
 
 + Create a folder to hold the install package and files.
 


### PR DESCRIPTION
## Summary
Mac AMD builds are build on xcode12. I have verified it works on v12.3.1, builds are also off v12.3.1, xcode 13.4.