### PR TITLE
Update Indexer Docs for 2.13.0 release

### DIFF
--- a/docs/clis/indexer/daemon.md
+++ b/docs/clis/indexer/daemon.md
@@ -40,6 +40,8 @@ indexer daemon [flags]
 
       --api-config-file string                 supply an API config file to enable/disable parameters
 
+      --catchpoint string                      initialize local ledger using fast catchup
+
   -c, --configfile string                      file path to configuration file (indexer.yml)
 
       --cpuprofile string                      file to record cpu profile to
@@ -65,6 +67,8 @@ indexer daemon [flags]
   -g, --genesis string                         path to genesis.json (defaults to genesis.json in algod data dir if that was set)
 
   -h, --help                                   help for daemon
+
+      --init-ledger                            initialize local ledger using sequential mode (default true)
 
   -f, --logfile string                         file to write logs to, if unset logs are written to standard out
 

--- a/docs/clis/indexer/util/block-generator/runner.md
+++ b/docs/clis/indexer/util/block-generator/runner.md
@@ -38,6 +38,8 @@ indexer util block-generator runner [flags]
 
   -p, --indexer-port uint                   Port to start the server at. This is useful if you have a prometheus server for collecting additional data. (default 4010)
 
+  -k, --keep-data-dir                       If set the validator will not delete the data directory after tests complete.
+
   -l, --log-level string                    LogLevel to use when starting Indexer. [error, warn, info, debug, trace] (default "error")
 
   -c, --postgres-connection-string string   Postgres connection string.


### PR DESCRIPTION
## Summary
Locally tried out the docs/scripts/reformat-all-commands.sh script to update docs for 2.13.0 release (Wed July 27th, 9:30 AM / 1:30PM UTC).

Please merge to update the docs. I only committed changes related to indexer. It looks like our algod documentation is ahead of rel/stable, so I didn't want to overwrite the algod documentation.
