### PR TITLE
removed reference to Algorand Studio and algorand vscode extension

### DIFF
--- a/docs/sdks/go/index.md
+++ b/docs/sdks/go/index.md
@@ -288,7 +288,5 @@ If you have any trouble compiling or running your program, please check the comp
 The Algorand community provides many editors, frameworks, and plugins that can be used to work with the Algorand Network. Tutorials have been created for configuring each of these for use with Algorand. Select your Editor preference below.
 
 * [Setting Up VSCode](https://developer.algorand.org/tutorials/vs-code-go/)
-* [Algorand VSCode Extension](https://developer.algorand.org/articles/intro-algorand-studio-algorand-vs-code-extension/)
-* [Algo Studio](https://developer.algorand.org/articles/intro-algorand-studio-algorand-vs-code-extension/)
 * [AlgoDEA IntelliJ Plugin](https://developer.algorand.org/articles/making-development-easier-algodea-intellij-plugin/)
 * [Algo Builder Framework](https://developer.algorand.org/articles/introducing-algorand-builder/)

--- a/docs/sdks/java/index.md
+++ b/docs/sdks/java/index.md
@@ -389,8 +389,6 @@ class GettingStarted{
 The Algorand community provides many editors, frameworks, and plugins that can be used to work with the Algorand Network. Tutorials have been created for configuring each of these for use with Algorand. Select your Editor preference below.
 
 - [Setting Up VSCode](https://developer.algorand.org/tutorials/vs-code-java/)
-- [Algorand Studio](https://developer.algorand.org/articles/intro-algorand-studio-algorand-vs-code-extension/)
-- [Algorand Studio VSCode Extension](https://developer.algorand.org/articles/intro-algorand-studio-algorand-vs-code-extension/)
 - [AlgoDEA IntelliJ Plugin](https://developer.algorand.org/articles/making-development-easier-algodea-intellij-plugin/)
 - [Algorand Builder Framework](https://developer.algorand.org/articles/introducing-algorand-builder/)
   

--- a/docs/sdks/javascript/index.md
+++ b/docs/sdks/javascript/index.md
@@ -332,10 +332,6 @@ The Algorand community provides many editors, frameworks, and plugins that can b
 
 * [Setting Up VSCode](https://developer.algorand.org/tutorials/vs-code-javascript/)
 
-* [Algorand Studio](https://developer.algorand.org/articles/intro-algorand-studio-algorand-vs-code-extension/)
-
-* [Algorand Studio VSCode Extension](https://developer.algorand.org/articles/intro-algorand-studio-algorand-vs-code-extension/)
-
 * [AlgoDEA IntelliJ Plugin](https://developer.algorand.org/articles/making-development-easier-algodea-intellij-plugin/)
 
 * [Algorand Builder Framework](https://developer.algorand.org/articles/introducing-algorand-builder/) and [Algo Builder Tutorial series](https://developer.algorand.org/tutorials/algorand-builder-tutorial-part1-creating-local-network-and-deploying-asa/)

--- a/docs/sdks/python/index.md
+++ b/docs/sdks/python/index.md
@@ -263,7 +263,5 @@ To view the transaction, open [AlgoExplorer](https://testnet.algoexplorer.io/){t
 The Algorand community provides many editors, frameworks, and plugins that can be used to work with the Algorand Network. Tutorials have been created for configuring each of these for use with Algorand. Select your Editor preference below.  
 
 * [Setting Up VSCode](https://developer.algorand.org/tutorials/vs-code-javascript/){target=_blank}  
-* [Algorand Studio](https://developer.algorand.org/articles/intro-algorand-studio-algorand-vs-code-extension/){target=_blank}  
-* [Algorand Studio VSCode Extension](https://developer.algorand.org/articles/intro-algorand-studio-algorand-vs-code-extension/){target=_blank}  
 * [AlgoDEA IntelliJ Plugin](https://developer.algorand.org/articles/making-development-easier-algodea-intellij-plugin/){target=_blank}  
 * [Algorand Builder Framework](https://developer.algorand.org/articles/introducing-algorand-builder/){target=_blank}  


### PR DESCRIPTION
fixed #693 

Removed reference to Algorand Studio and Algorand VScode extension as they are out of date