### PR TITLE
Dryrun/tealdbg warning for boxes being unsupported

### DIFF
--- a/docs/clis/goal/clerk/dryrun-remote.md
+++ b/docs/clis/goal/clerk/dryrun-remote.md
@@ -10,7 +10,8 @@ Test a program with algod's dryrun REST endpoint
 
 ### Synopsis
 
-
+!!! warning
+    As of AVMv8, `dryrun` will no longer work with any contract that uses box storage. A new endpoint that will replace `dryrun` is current in development.
 
 Test a TEAL program with algod's dryrun REST endpoint under various conditions and verbosity.
 

--- a/docs/clis/goal/clerk/dryrun.md
+++ b/docs/clis/goal/clerk/dryrun.md
@@ -10,6 +10,8 @@ Test a program offline
 
 ### Synopsis
 
+!!! warning
+    As of AVMv8, `dryrun` will no longer work with any contract that uses box storage. Work is being done on a new endpoint that will replace `dryrun`
 
 
 Test a TEAL program offline under various conditions and verbosity.

--- a/docs/clis/tealdbg/tealdbg.md
+++ b/docs/clis/tealdbg/tealdbg.md
@@ -10,7 +10,8 @@ Algorand TEAL Debugger
 
 ### Synopsis
 
-
+!!! warning
+    As of AVMv8, `tealdbg` will no longer work with any contract that uses box storage. A new debugging tool that will replace `tealdbg` is currently in development.
 
 Debug a local or remote TEAL code in controlled environment
 

--- a/docs/get-details/dapps/smart-contracts/debugging.md
+++ b/docs/get-details/dapps/smart-contracts/debugging.md
@@ -1,5 +1,8 @@
 title: Debugging smart contracts
 
+!!! warning
+    As of AVMv8, `dryrun` will no longer work with any contract that uses box storage. A new endpoint to replace `dryrun` along with a new tool to replace `tealdbg` is current in development.
+
 Smart contracts can be debugged using two different methods. The first is an interactive debugger that uses the `tealdbg` command-line tool to launch a debug session where the smart contract can be examined as the contract is being evaluated. The second method uses the `goal clerk dryrun-remote` command which outputs a line by line result of the evaluation of the smart contract.  These two methods are described below.
 
 # Using the TEAL debugger


### PR DESCRIPTION
Added warnings on the main doc pages for dryrun/tealdbg. There are other mentions of dryrun/tealdbg throughout the docs (and portal as a whole) but I figured these main pages are a good place to put the warning and we can go from there if needed. 