### PR TITLE
py-algorand-sdk:  Update examples for v2.0.0

### DIFF
--- a/docs/archive/build-apps/hello_world.md
+++ b/docs/archive/build-apps/hello_world.md
@@ -247,7 +247,7 @@ fields.
 === "Python"
 
     ```python 
-    from algosdk.future.transaction import PaymentTxn
+    from algosdk.transaction import PaymentTxn
 
     params = algod_client.suggested_params()
     # comment out the next two (2) lines to use suggested fees

--- a/docs/get-details/accounts/create.md
+++ b/docs/get-details/accounts/create.md
@@ -1023,7 +1023,7 @@ The following code shows how to generate a multisignature account composed of th
 === "Python"
 	```python
 	from algosdk import mnemonic
-	from algosdk.future.transaction import Multisig
+	from algosdk.transaction import Multisig
 	# Shown for demonstration purposes. NEVER reveal secret mnemonics in practice.
 	# Change these values to use the accounts created previously.
 	# Change these values with mnemonics

--- a/docs/get-details/accounts/rekey.md
+++ b/docs/get-details/accounts/rekey.md
@@ -320,7 +320,7 @@ In part 1, rekey from Account 3 to allow to sign from Account 1. Then in part 2,
     import json
     from algosdk import mnemonic
     from algosdk.v2client import algod
-    from algosdk.future.transaction import *
+    from algosdk.transaction import *
 
 
     def getting_started_example():

--- a/docs/get-details/dapps/pyteal/index.md
+++ b/docs/get-details/dapps/pyteal/index.md
@@ -601,7 +601,7 @@ The complete example is shown below.
 ```python
 import base64
 
-from algosdk.future import transaction
+from algosdk import transaction
 from algosdk import account, mnemonic
 from algosdk.atomic_transaction_composer import *
 from algosdk.v2client import algod
@@ -945,7 +945,7 @@ A few global variables are created and some utility functions are added to the p
 ```python
 import base64
 
-from algosdk.future import transaction
+from algosdk import transaction
 from algosdk import mnemonic
 from algosdk.v2client import algod
 from pyteal import *
@@ -1067,7 +1067,7 @@ A simple payment transaction is then created to fund the escrow with a little ov
 ```python
 import base64
 
-from algosdk.future import transaction
+from algosdk import transaction
 from algosdk import mnemonic
 from algosdk.v2client import algod
 from pyteal import *

--- a/docs/get-details/dapps/smart-contracts/frontend/smartsigs.md
+++ b/docs/get-details/dapps/smart-contracts/frontend/smartsigs.md
@@ -236,7 +236,7 @@ The response result from the TEAL `compile` command above is used to create the 
 === "Python"
 	```python
         import base64
-        from algosdk.future.transaction import LogicSigAccount
+        from algosdk.transaction import LogicSigAccount
 
         programstr = response['result']
         t = programstr.encode()
@@ -284,7 +284,7 @@ The SDKs require that parameters to a smart signature TEAL program be in byte ar
 
 === "Python"
 	```python
-        from algosdk.future.transaction import LogicSigAccount
+        from algosdk.transaction import LogicSigAccount
 
         # string parameter
         arg_str = "my string"
@@ -455,7 +455,7 @@ int 123
 	```python
         from algosdk import transaction, account, mnemonic
         from algosdk.v2client import algod
-        from algosdk.future.transaction import *
+        from algosdk.transaction import *
         import os
         import base64
         import json
@@ -911,7 +911,7 @@ The following example illustrates signing a transaction with a created logic sig
     from algosdk.v2client import algod
     import os
     import base64
-    from algosdk.future.transaction import *
+    from algosdk.transaction import *
     # Read a file
     def load_resource(res):
         dir_path = os.path.dirname(os.path.realpath(__file__))

--- a/docs/get-details/transactions/signatures.md
+++ b/docs/get-details/transactions/signatures.md
@@ -223,9 +223,9 @@ Extend the example from the [Multisignature Account](../../accounts/create#multi
     import json
     from algosdk.v2client import algod
     from algosdk import account, encoding, mnemonic
-    from algosdk.future.transaction import Multisig, PaymentTxn, MultisigTransaction
+    from algosdk.transaction import Multisig, PaymentTxn, MultisigTransaction
     import base64
-    from algosdk.future.transaction import *
+    from algosdk.transaction import *
 
     # Change these values with mnemonics
     mnemonic1 = "PASTE phrase for account 1"

--- a/docs/sdks/python/index.md
+++ b/docs/sdks/python/index.md
@@ -110,7 +110,7 @@ Transactions are used to interact with the Algorand network. To create a payment
 ​
 ```python
 # build transaction
-from algosdk.future import transaction
+from algosdk import transaction
 from algosdk import constants
 
 
@@ -183,7 +183,7 @@ import json
 import base64
 from algosdk import account, mnemonic, constants
 from algosdk.v2client import algod
-from algosdk.future import transaction
+from algosdk import transaction
 
 
 def generate_algorand_keypair():

--- a/examples/assets/v2/python/asset_example.py
+++ b/examples/assets/v2/python/asset_example.py
@@ -2,8 +2,8 @@ import json
 import base64
 from algosdk.v2client import algod
 from algosdk import account, mnemonic
-from algosdk.future.transaction import AssetConfigTxn, AssetTransferTxn, AssetFreezeTxn
-from algosdk.future.transaction import *
+from algosdk.transaction import AssetConfigTxn, AssetTransferTxn, AssetFreezeTxn
+from algosdk.transaction import *
 
 
 # Shown for demonstration purposes. NEVER reveal secret mnemonics in practice.

--- a/examples/atomic_transfers/v2/python/atomic_transfer.py
+++ b/examples/atomic_transfers/v2/python/atomic_transfer.py
@@ -2,7 +2,7 @@ import json
 from algosdk.v2client import algod
 from algosdk import mnemonic
 from algosdk import account
-from algosdk.future.transaction import *
+from algosdk.transaction import *
 
 # This atomic transfer example code requires three (3) acounts:
 #  - account_1 requires a user-defined mnemonic and be funded with 1001000 microAlgos

--- a/examples/multisig/v2/python/multisig_transaction.py
+++ b/examples/multisig/v2/python/multisig_transaction.py
@@ -1,9 +1,9 @@
 import json
 from algosdk.v2client import algod
 from algosdk import account, encoding, mnemonic
-from algosdk.future.transaction import Multisig, PaymentTxn, MultisigTransaction
+from algosdk.transaction import Multisig, PaymentTxn, MultisigTransaction
 import base64
-from algosdk.future.transaction import *
+from algosdk.transaction import *
 
 # Change these values with mnemonics
 mnemonic1 = "PASTE phrase for account 1"

--- a/examples/offline/V2/python/multisig_offline.py
+++ b/examples/offline/V2/python/multisig_offline.py
@@ -1,10 +1,10 @@
 import json
 from algosdk.v2client import algod
 from algosdk import account, encoding, mnemonic
-from algosdk.future.transaction import Multisig, PaymentTxn, MultisigTransaction
+from algosdk.transaction import Multisig, PaymentTxn, MultisigTransaction
 import base64
 import os
-from algosdk.future.transaction import *
+from algosdk.transaction import *
 
 def connect_to_network():
     # Specify your node address and token. This must be updated.

--- a/examples/offline/V2/python/offline.py
+++ b/examples/offline/V2/python/offline.py
@@ -4,8 +4,8 @@ import base64
 import os
 from algosdk import mnemonic
 from algosdk.v2client import algod
-from algosdk.future.transaction import PaymentTxn
-from algosdk.future.transaction import *
+from algosdk.transaction import PaymentTxn
+from algosdk.transaction import *
 
 
 def connect_to_network():

--- a/examples/smart_contracts/v2/python/account_delegation.py
+++ b/examples/smart_contracts/v2/python/account_delegation.py
@@ -3,7 +3,7 @@ from algosdk.v2client import algod
 
 import os
 import base64
-from algosdk.future.transaction import *
+from algosdk.transaction import *
 
 # Read a file
 def load_resource(res):

--- a/examples/smart_contracts/v2/python/contract_account.py
+++ b/examples/smart_contracts/v2/python/contract_account.py
@@ -1,6 +1,6 @@
 from algosdk import transaction, account, mnemonic
 from algosdk.v2client import algod
-from algosdk.future.transaction import *
+from algosdk.transaction import *
 import os
 import base64
 import json

--- a/examples/smart_contracts/v2/python/dryrun_debugging.py
+++ b/examples/smart_contracts/v2/python/dryrun_debugging.py
@@ -1,6 +1,6 @@
 from algosdk import algod, transaction, account, mnemonic
 from algosdk.v2client import algod
-from algosdk.future.transaction import *
+from algosdk.transaction import *
 import os
 import base64
 from algosdk.v2client.models import DryrunRequest, DryrunSource

--- a/examples/smart_contracts/v2/python/stateful_smart_contracts.py
+++ b/examples/smart_contracts/v2/python/stateful_smart_contracts.py
@@ -9,7 +9,7 @@ import json
 
 from algosdk import account, mnemonic
 from algosdk.v2client import algod
-from algosdk.future.transaction import *
+from algosdk.transaction import *
 
 # user declared account mnemonics
 # never use mnemonics in code, for demo purposes

--- a/examples/start_building/v2/python/your_first_transaction.py
+++ b/examples/start_building/v2/python/your_first_transaction.py
@@ -4,7 +4,7 @@ import base64
 from algosdk import account
 
 from algosdk.v2client import algod
-from algosdk.future import transaction
+from algosdk import transaction
 
 
 def getting_started_example():


### PR DESCRIPTION
Updates py-algorand-sdk examples for the removal for `future` package in v2.0.0.  
* Corresponding SDK change:  https://github.com/algorand/py-algorand-sdk/pull/414.
* All v2.0.0 changes discussed in https://github.com/algorand/py-algorand-sdk/issues/384 / https://github.com/algorand/py-algorand-sdk/pull/415.

The PR makes changes mechanically via `find . -type f -exec sed -i "" "s/algosdk.future/algosdk/g" {} \;`.