### PR TITLE
go-algorand-sdk:  Update future package examples for v2.0.0

### DIFF
--- a/docs/get-details/asa.md
+++ b/docs/get-details/asa.md
@@ -327,7 +327,7 @@ Create assets using either the SDKs or `goal`. When using the SDKs supply all cr
 	}
 	fmt.Printf("Submitted transaction %s\n", sendResponse)
 	// Wait for confirmation
-	confirmedTxn, err := future.WaitForConfirmation(algodClient,txid,  4, context.Background())
+	confirmedTxn, err := transaction.WaitForConfirmation(algodClient,txid,  4, context.Background())
 	if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", txid)
 		return

--- a/docs/get-details/atc.md
+++ b/docs/get-details/atc.md
@@ -106,16 +106,16 @@ Constructing a Transaction with Signer and adding it to the transaction composer
     acct, _ := GetAccount()
 
     // Create signer object
-	signer := future.BasicAccountTransactionSigner{Account: acct}
+	signer := transaction.BasicAccountTransactionSigner{Account: acct}
 
     // Get suggested params from client
 	sp, _ := client.SuggestedParams().Do(context.Background())
 
     // Create a transaction
-	ptxn, _ := future.MakePaymentTxn(acct.Address.String(), acct.Address.String(), 10000, nil, "", sp)
+	ptxn, _ := transaction.MakePaymentTxn(acct.Address.String(), acct.Address.String(), 10000, nil, "", sp)
 
     // Construct TransactionWithSigner
-	tws := future.TransactionWithSigner{Txn: txn, Signer: signer}
+	tws := transaction.TransactionWithSigner{Txn: txn, Signer: signer}
 
     // Pass TransactionWithSigner to atc
 
@@ -264,7 +264,7 @@ Once the Contract object is constructed, it can be used to look up and pass meth
         return mcp
     }
 
-	mcp := future.AddMethodCallParams{
+	mcp := transaction.AddMethodCallParams{
 		AppID:           contract.Networks[genesis_hash].AppID,
 		Sender:          acct.Address,
 		SuggestedParams: sp,
@@ -279,8 +279,8 @@ Once the Contract object is constructed, it can be used to look up and pass meth
 
     // This method requires a `transaction` as its second argument. Construct the transaction and pass it in as an argument.
     // The ATC will handle adding it to the group transaction and setting the reference in the application arguments.
-	txn, _ := future.MakePaymentTxn(acct.Address.String(), acct.Address.String(), 10000, nil, "", sp)
-	stxn := future.TransactionWithSigner{Txn: txn, Signer: signer}
+	txn, _ := transaction.MakePaymentTxn(acct.Address.String(), acct.Address.String(), 10000, nil, "", sp)
+	stxn := transaction.TransactionWithSigner{Txn: txn, Signer: signer}
 	atc.AddMethodCall(combine(mcp, getMethod(contract, "txntest"), []interface{}{10000, stxn, 1000}))
 
     ```

--- a/docs/get-details/atomic_transfers.md
+++ b/docs/get-details/atomic_transfers.md
@@ -348,7 +348,7 @@ The transaction group is now broadcast to the network.
         fmt.Printf("failed to send transaction: %s\n", err)
         return
     }
-    confirmedTxn, err := future.WaitForConfirmation(algodClient, pendingTxID, 4, context.Background())
+    confirmedTxn, err := transaction.WaitForConfirmation(algodClient, pendingTxID, 4, context.Background())
     if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", pendingTxID)
         return

--- a/docs/get-details/dapps/smart-contracts/debugging.md
+++ b/docs/get-details/dapps/smart-contracts/debugging.md
@@ -121,7 +121,7 @@ This file may be msgpack or json and can be created using goal or the SDKs
 === "Go"
     ```go
 
-	app_txn, err := future.MakeApplicationNoOpTx(app_id, nil, []string{other_addr}, nil, []uint64{asset_id}, sp, addr, nil, types.Digest{}, [32]byte{}, types.Address{})
+	app_txn, err := transaction.MakeApplicationNoOpTx(app_id, nil, []string{other_addr}, nil, []uint64{asset_id}, sp, addr, nil, types.Digest{}, [32]byte{}, types.Address{})
 	if err != nil {
 		log.Fatalf("Failed to create app call txn: %+v", err)
 	}
@@ -133,7 +133,7 @@ This file may be msgpack or json and can be created using goal or the SDKs
 	s_app_txn := types.SignedTxn{}
 	msgpack.Decode(s_app_bytes, &s_app)
 
-    drr, err := future.CreateDryrun(client, []types.SignedTxn{s_app_txn}, nil, context.Background())
+    drr, err := transaction.CreateDryrun(client, []types.SignedTxn{s_app_txn}, nil, context.Background())
 	if err != nil {
 		log.Fatalf("Failed to create dryrun: %+v", err)
 	}
@@ -271,7 +271,7 @@ The payload for [creating a dryrun request](#creating-a-dryrun-dump-file) has th
     ```go
     // ... 
     // Create the dryrun request object
-    dryrunRequest, _ := future.CreateDryrun(client, txns, nil, context.Background())
+    dryrunRequest, _ := transaction.CreateDryrun(client, txns, nil, context.Background())
 
     // Pass dryrun request to algod server
     dryrunResponse, _ := client.TealDryrun(dryrunRequest).Do(context.Background())

--- a/docs/get-details/dapps/smart-contracts/frontend/apps.md
+++ b/docs/get-details/dapps/smart-contracts/frontend/apps.md
@@ -364,7 +364,7 @@ Construct the transaction with defined values:
 === "Go"
 	```go
     // create unsigned transaction
-    txn, _ := future.MakeApplicationCreateTx(false, approvalProgram, clearProgram, globalSchema, localSchema, 
+    txn, _ := transaction.MakeApplicationCreateTx(false, approvalProgram, clearProgram, globalSchema, localSchema, 
                         nil, nil, nil, nil, params, creatorAccount.Address, nil, 
                         types.Digest{}, [32]byte{}, types.Address{}, uint32(0))
     ```
@@ -445,7 +445,7 @@ Sign, send, await confirmation and display the results:
     fmt.Printf("Submitted transaction %s\n", sendResponse)
 
     // Wait for confirmation
-    confirmedTxn, err := future.WaitForConfirmation(client, txID, 4, context.Background())
+    confirmedTxn, err := transaction.WaitForConfirmation(client, txID, 4, context.Background())
     if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", txID)
         return
@@ -526,7 +526,7 @@ Construct the transaction with defined values:
 === "Go"
 	```go
     // create unsigned transaction
-    txn, _ := future.MakeApplicationOptInTx(index, nil, nil, nil, nil, params,
+    txn, _ := transaction.MakeApplicationOptInTx(index, nil, nil, nil, nil, params,
                             sender, nil, types.Digest{}, [32]byte{}, types.Address{})
     ```
 
@@ -636,7 +636,7 @@ The user may now [call](../apps/#call-the-stateful-smart-contract) the applicati
 === "Go"
 	```go
     // create unsigned transaction
-    txn, _:= future.MakeApplicationNoOpTx(index, appArgs, nil, nil, nil, params, sender, 
+    txn, _:= transaction.MakeApplicationNoOpTx(index, appArgs, nil, nil, nil, params, sender, 
                             nil, types.Digest{}, [32]byte{}, types.Address{})
 
     // sign, send, await 
@@ -802,7 +802,7 @@ Construct the update transaction and await the response:
 === "Go"
 	```go
         // create unsigned transaction
-        txn, _ := future.MakeApplicationUpdateTx(index, nil, nil, nil, nil, 
+        txn, _ := transaction.MakeApplicationUpdateTx(index, nil, nil, nil, nil, 
                             approvalProgram, clearProgram, params, creatorAccount.Address, 
                             nil, types.Digest{}, [32]byte{}, types.Address{})
 
@@ -902,7 +902,7 @@ The refactored application expects a timestamp be supplied with the application 
     appArgs[0] = []byte(now)
 
     // create unsigned transaction
-    txn, _ := future.MakeApplicationNoOpTx(index, appArgs, nil, nil, nil, params, sender, 
+    txn, _ := transaction.MakeApplicationNoOpTx(index, appArgs, nil, nil, nil, params, sender, 
                                 nil, types.Digest{}, [32]byte{}, types.Address{})
 
     // sign, send, await
@@ -963,7 +963,7 @@ The user may discontinue use of the application by sending a [close out](../apps
 === "Go"
 	```go
     // create unsigned transaction
-    txn, _ := future.MakeApplicationCloseOutTx(index, nil, nil, nil, nil, params, account.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
+    txn, _ := transaction.MakeApplicationCloseOutTx(index, nil, nil, nil, nil, params, account.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
 
     // sign, send, await
 
@@ -1020,7 +1020,7 @@ The approval program defines the creator as the only account able to [delete the
 === "Go"
 	```go
     // create unsigned transaction
-    txn, _ := future.MakeApplicationDeleteTx(index, nil, nil, nil, nil, params, sender, 
+    txn, _ := transaction.MakeApplicationDeleteTx(index, nil, nil, nil, nil, params, sender, 
                             nil, types.Digest{}, [32]byte{}, types.Address{})
 
     // sign, send, await
@@ -1079,7 +1079,7 @@ The user may [clear the local state](../apps/#the-lifecycle-of-a-stateful-smart-
 === "Go"
 	```go
     // create unsigned transaction
-    txn, _ := future.MakeApplicationClearStateTx(index, nil, nil, nil, nil, params, sender, 
+    txn, _ := transaction.MakeApplicationClearStateTx(index, nil, nil, nil, nil, params, sender, 
                             nil, types.Digest{}, [32]byte{}, types.Address{})
 
     // sign, send, await

--- a/docs/get-details/dapps/smart-contracts/frontend/smartsigs.md
+++ b/docs/get-details/dapps/smart-contracts/frontend/smartsigs.md
@@ -789,7 +789,7 @@ int 123
             fmt.Printf("Sending failed with %v\n", err)
         }
         // Wait for confirmation
-        confirmedTxn, err := future.WaitForConfirmation(algodClient,transactionID,  4, context.Background())
+        confirmedTxn, err := transaction.WaitForConfirmation(algodClient,transactionID,  4, context.Background())
         if err != nil {
             fmt.Printf("Error waiting for confirmation on txID: %s\n", transactionID)
             return
@@ -1268,7 +1268,7 @@ The following example illustrates signing a transaction with a created logic sig
             fmt.Printf("Sending failed with %v\n", err)
         }
         // Wait for confirmation
-        confirmedTxn, err := future.WaitForConfirmation(algodClient,transactionID,  4, context.Background())
+        confirmedTxn, err := transaction.WaitForConfirmation(algodClient,transactionID,  4, context.Background())
         if err != nil {
             fmt.Printf("Error waiting for confirmation on txID: %s\n", transactionID)
             return

--- a/docs/get-details/encoding.md
+++ b/docs/get-details/encoding.md
@@ -258,7 +258,7 @@ Create a payment transaction from one account to another using suggested paramet
 	// Error handling omitted for brevity
 	sp, _ := client.SuggestedParams().Do(context.Background())
 
-	pay_txn, _ := future.MakePaymentTxn(acct1.Address.String(), acct2.Address.String(), 10000, nil, "", sp)
+	pay_txn, _ := transaction.MakePaymentTxn(acct1.Address.String(), acct2.Address.String(), 10000, nil, "", sp)
 
 	var pay_txn_bytes = make([]byte, 1e3)
 	base64.StdEncoding.Encode(pay_txn_bytes, msgpack.Encode(pay_txn))

--- a/docs/get-details/transactions/offline_transactions.md
+++ b/docs/get-details/transactions/offline_transactions.md
@@ -206,7 +206,7 @@ Unsigned transactions require the transaction object to be created before writin
         fmt.Printf("Submitted transaction %s\n", sendResponse)
 
         // Wait for confirmation
-        confirmedTxn, err := future.WaitForConfirmation(algodClient,txID,  4, context.Background())
+        confirmedTxn, err := transaction.WaitForConfirmation(algodClient,txID,  4, context.Background())
         if err != nil {
             fmt.Printf("Error waiting for confirmation on txID: %s\n", sendResponse)
             return
@@ -401,7 +401,7 @@ Signed Transactions are similar, but require an account to sign the transaction 
         fmt.Printf("Submitted transaction %s\n", sendResponse)
 
         // Wait for confirmation
-        confirmedTxn, err := future.WaitForConfirmation(algodClient,sendResponse,  4, context.Background())
+        confirmedTxn, err := transaction.WaitForConfirmation(algodClient,sendResponse,  4, context.Background())
         if err != nil {
             fmt.Printf("Error waiting for confirmation on txID: %s\n", sendResponse)
             return

--- a/docs/get-details/transactions/signatures.md
+++ b/docs/get-details/transactions/signatures.md
@@ -613,7 +613,7 @@ Extend the example from the [Multisignature Account](../../accounts/create#multi
 
 
         // Wait for confirmation
-        confirmedTxn, err := future.WaitForConfirmation(algodClient,txid,  4, context.Background())
+        confirmedTxn, err := transaction.WaitForConfirmation(algodClient,txid,  4, context.Background())
         if err != nil {
             fmt.Printf("Error waiting for confirmation on txID: %s\n", txid)
             return

--- a/docs/sdks/go/index.md
+++ b/docs/sdks/go/index.md
@@ -225,7 +225,7 @@ if err != nil {
 fmt.Printf("Submitted transaction %s\n", sendResponse)
 
 // Wait for confirmation
-confirmedTxn, err := future.WaitForConfirmation(algodClient, txID, 4, context.Background())
+confirmedTxn, err := transaction.WaitForConfirmation(algodClient, txID, 4, context.Background())
 if err != nil {
     fmt.Printf("Error waiting for confirmation on txID: %s\n", txID)
     return

--- a/examples/assets/v2/go/assetExample.go
+++ b/examples/assets/v2/go/assetExample.go
@@ -202,7 +202,7 @@ func main() {
 	fmt.Printf("Submitted transaction %s\n", sendResponse)
 
 	// Wait for confirmation
-	confirmedTxn, err := future.WaitForConfirmation(algodClient,txid,  4, context.Background())
+	confirmedTxn, err := transaction.WaitForConfirmation(algodClient,txid,  4, context.Background())
 	if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", txid)
 		return

--- a/examples/atomic_transfers/v2/go/atomicTransfer.go
+++ b/examples/atomic_transfers/v2/go/atomicTransfer.go
@@ -201,7 +201,7 @@ func main() {
 	}
     fmt.Printf("Submitted transaction %s\n", pendingTxID)
 
-    confirmedTxn, err := future.WaitForConfirmation(algodClient, pendingTxID, 4, context.Background())
+    confirmedTxn, err := transaction.WaitForConfirmation(algodClient, pendingTxID, 4, context.Background())
     if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", pendingTxID)
         return

--- a/examples/multisig/v2/go/multisig.go
+++ b/examples/multisig/v2/go/multisig.go
@@ -164,7 +164,7 @@ func main() {
 
 
 	// Wait for confirmation
-	confirmedTxn, err := future.WaitForConfirmation(algodClient,txid,  4, context.Background())
+	confirmedTxn, err := transaction.WaitForConfirmation(algodClient,txid,  4, context.Background())
 	if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", txid)
 		return

--- a/examples/offline/V2/go/multisigOffline.go
+++ b/examples/offline/V2/go/multisigOffline.go
@@ -200,7 +200,7 @@ func readUnsignedMultisigTransaction() {
 
 
 	// Wait for confirmation
-	confirmedTxn, err := future.WaitForConfirmation(algodClient,txid,  4, context.Background())
+	confirmedTxn, err := transaction.WaitForConfirmation(algodClient,txid,  4, context.Background())
 	if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", txid)
 		return
@@ -322,7 +322,7 @@ func readSignedMultisigTransaction() {
 
 
 	// Wait for confirmation
-	confirmedTxn, err := future.WaitForConfirmation(algodClient,txid,  4, context.Background())
+	confirmedTxn, err := transaction.WaitForConfirmation(algodClient,txid,  4, context.Background())
 	if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", txid)
 		return

--- a/examples/offline/V2/go/offline.go
+++ b/examples/offline/V2/go/offline.go
@@ -142,7 +142,7 @@ func readUnsignedTransaction() {
 
 
 	// Wait for confirmation
-	confirmedTxn, err := future.WaitForConfirmation(algodClient,txID,  4, context.Background())
+	confirmedTxn, err := transaction.WaitForConfirmation(algodClient,txID,  4, context.Background())
 	if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", txID)
 		return
@@ -235,7 +235,7 @@ func readSignedTransaction() {
 
 
 	// Wait for confirmation
-	confirmedTxn, err := future.WaitForConfirmation(algodClient,sendResponse,  4, context.Background())
+	confirmedTxn, err := transaction.WaitForConfirmation(algodClient,sendResponse,  4, context.Background())
 	if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", sendResponse)
 		return

--- a/examples/smart_contracts/v2/go/accountDelegation.go
+++ b/examples/smart_contracts/v2/go/accountDelegation.go
@@ -138,7 +138,7 @@ func main() {
     }
 
 	// Wait for confirmation
-	confirmedTxn, err := future.WaitForConfirmation(algodClient,transactionID,  4, context.Background())
+	confirmedTxn, err := transaction.WaitForConfirmation(algodClient,transactionID,  4, context.Background())
 	if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", transactionID)
 		return

--- a/examples/smart_contracts/v2/go/contractAccount.go
+++ b/examples/smart_contracts/v2/go/contractAccount.go
@@ -130,7 +130,7 @@ func main() {
 
 
 	// Wait for confirmation
-	confirmedTxn, err := future.WaitForConfirmation(algodClient,transactionID,  4, context.Background())
+	confirmedTxn, err := transaction.WaitForConfirmation(algodClient,transactionID,  4, context.Background())
 	if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", transactionID)
 		return

--- a/examples/smart_contracts/v2/go/dryrunDebugging.go
+++ b/examples/smart_contracts/v2/go/dryrunDebugging.go
@@ -194,7 +194,7 @@ func main() {
     fmt.Printf("Transaction ID: %v\n", transactionID)
 
     // Wait for confirmation
-	confirmedTxn, err := future.WaitForConfirmation(algodClient,txID,  4, context.Background())
+	confirmedTxn, err := transaction.WaitForConfirmation(algodClient,txID,  4, context.Background())
 	if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", txID)
 		return

--- a/examples/smart_contracts/v2/go/statefulSmartContracts.go
+++ b/examples/smart_contracts/v2/go/statefulSmartContracts.go
@@ -267,7 +267,7 @@ func createApp(client *algod.Client, creatorAccount crypto.Account, approvalProg
 	// params.Fee = 1000
 
 	// create unsigned transaction
-	txn, err := future.MakeApplicationCreateTx(false, approvalProgram, clearProgram, globalSchema, localSchema, nil,
+	txn, err := transaction.MakeApplicationCreateTx(false, approvalProgram, clearProgram, globalSchema, localSchema, nil,
 		nil, nil, nil, params, creatorAccount.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
 	if err != nil {
 		fmt.Printf("Error creating transaction: %s\n", err)
@@ -292,7 +292,7 @@ func createApp(client *algod.Client, creatorAccount crypto.Account, approvalProg
 
 
 	// Wait for confirmation
-	confirmedTxn, err := future.WaitForConfirmation(client, txID,  4, context.Background())
+	confirmedTxn, err := transaction.WaitForConfirmation(client, txID,  4, context.Background())
 	if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", txID)
 		return
@@ -319,7 +319,7 @@ func optInApp(client *algod.Client, account crypto.Account, index uint64) {
 	// params.Fee = 1000
 
 	// create unsigned transaction
-	txn, err := future.MakeApplicationOptInTx(index, nil, nil, nil, nil, params, account.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
+	txn, err := transaction.MakeApplicationOptInTx(index, nil, nil, nil, nil, params, account.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
 	if err != nil {
 		fmt.Printf("Error creating transaction: %s\n", err)
 		return
@@ -343,7 +343,7 @@ func optInApp(client *algod.Client, account crypto.Account, index uint64) {
 
 
 	// Wait for confirmation
-	confirmedTxn, err := future.WaitForConfirmation(client, txID,  4, context.Background())
+	confirmedTxn, err := transaction.WaitForConfirmation(client, txID,  4, context.Background())
 	if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", txID)
 		return
@@ -367,7 +367,7 @@ func callApp(client *algod.Client, account crypto.Account, index uint64, appArgs
 	// params.Fee = 1000
 
 	// create unsigned transaction
-	txn, err := future.MakeApplicationNoOpTx(index, appArgs, nil, nil, nil, params, account.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
+	txn, err := transaction.MakeApplicationNoOpTx(index, appArgs, nil, nil, nil, params, account.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
 	if err != nil {
 		fmt.Printf("Error creating transaction: %s\n", err)
 		return
@@ -391,7 +391,7 @@ func callApp(client *algod.Client, account crypto.Account, index uint64, appArgs
 
 
 	// Wait for confirmation
-	confirmedTxn, err := future.WaitForConfirmation(client, txID,  4, context.Background())
+	confirmedTxn, err := transaction.WaitForConfirmation(client, txID,  4, context.Background())
 	if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", txID)
 		return
@@ -443,7 +443,7 @@ func updateApp(client *algod.Client, creatorAccount crypto.Account, index uint64
 	// params.Fee = 1000
 
 	// create unsigned transaction
-	txn, err := future.MakeApplicationUpdateTx(index, nil, nil, nil, nil, approvalProgram, clearProgram, params, creatorAccount.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
+	txn, err := transaction.MakeApplicationUpdateTx(index, nil, nil, nil, nil, approvalProgram, clearProgram, params, creatorAccount.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
 	if err != nil {
 		fmt.Printf("Error creating transaction: %s\n", err)
 		return
@@ -467,7 +467,7 @@ func updateApp(client *algod.Client, creatorAccount crypto.Account, index uint64
 
 
 	// Wait for confirmation
-	confirmedTxn, err := future.WaitForConfirmation(client, txID,  4, context.Background())
+	confirmedTxn, err := transaction.WaitForConfirmation(client, txID,  4, context.Background())
 	if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", txID)
 		return
@@ -490,7 +490,7 @@ func closeOutApp(client *algod.Client, account crypto.Account, index uint64) {
 	// params.Fee = 1000
 
 	// create unsigned transaction
-	txn, err := future.MakeApplicationCloseOutTx(index, nil, nil, nil, nil, params, account.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
+	txn, err := transaction.MakeApplicationCloseOutTx(index, nil, nil, nil, nil, params, account.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
 	if err != nil {
 		fmt.Printf("Error creating transaction: %s\n", err)
 		return
@@ -514,7 +514,7 @@ func closeOutApp(client *algod.Client, account crypto.Account, index uint64) {
 
 
 	// Wait for confirmation
-	confirmedTxn, err := future.WaitForConfirmation(client, txID,  4, context.Background())
+	confirmedTxn, err := transaction.WaitForConfirmation(client, txID,  4, context.Background())
 	if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", txID)
 		return
@@ -538,7 +538,7 @@ func deleteApp(client *algod.Client, account crypto.Account, index uint64) {
 	// params.Fee = 1000
 
 	// create unsigned transaction
-	txn, err := future.MakeApplicationDeleteTx(index, nil, nil, nil, nil, params, account.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
+	txn, err := transaction.MakeApplicationDeleteTx(index, nil, nil, nil, nil, params, account.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
 	if err != nil {
 		fmt.Printf("Error creating transaction: %s\n", err)
 		return
@@ -562,7 +562,7 @@ func deleteApp(client *algod.Client, account crypto.Account, index uint64) {
 
 
 	// Wait for confirmation
-	confirmedTxn, err := future.WaitForConfirmation(client, txID,  4, context.Background())
+	confirmedTxn, err := transaction.WaitForConfirmation(client, txID,  4, context.Background())
 	if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", txID)
 		return
@@ -585,7 +585,7 @@ func clearApp(client *algod.Client, account crypto.Account, index uint64) {
 	// params.Fee = 1000
 
 	// create unsigned transaction
-	txn, err := future.MakeApplicationClearStateTx(index, nil, nil, nil, nil, params, account.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
+	txn, err := transaction.MakeApplicationClearStateTx(index, nil, nil, nil, nil, params, account.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
 	if err != nil {
 		fmt.Printf("Error creating transaction: %s\n", err)
 		return
@@ -609,7 +609,7 @@ func clearApp(client *algod.Client, account crypto.Account, index uint64) {
 
 
 	// Wait for confirmation
-	confirmedTxn, err := future.WaitForConfirmation(client, txID,  4, context.Background())
+	confirmedTxn, err := transaction.WaitForConfirmation(client, txID,  4, context.Background())
 	if err != nil {
 		fmt.Printf("Error waiting for confirmation on txID: %s\n", txID)
 		return

--- a/examples/start_building/v2/go/yourFirstTransaction.go
+++ b/examples/start_building/v2/go/yourFirstTransaction.go
@@ -97,7 +97,7 @@ func main() {
 	fmt.Printf("Submitted transaction %s\n", sendResponse)
 
 	// Wait for confirmation
-	confirmedTxn, err := future.WaitForConfirmation(algodClient, txID, 4)
+	confirmedTxn, err := transaction.WaitForConfirmation(algodClient, txID, 4)
 	if err != nil {
 		fmt.Printf("Error wating for confirmation on txID: %s\n", txID)
 		return


### PR DESCRIPTION
Updates go-algorand-sdk for the removal of the `future` package in v2.0.0.
* Corresponding SDK change:  https://github.com/algorand/go-algorand-sdk/pull/454
* All v2.0.0 breaking changes discussed in https://github.com/algorand/go-algorand-sdk/issues/343 / https://github.com/algorand/go-algorand-sdk/pull/449.