### PR TITLE
go-algorand-sdk:  Update SignLogicsigTransaction examples for v2.0.0

### DIFF
--- a/docs/get-details/dapps/smart-contracts/frontend/smartsigs.md
+++ b/docs/get-details/dapps/smart-contracts/frontend/smartsigs.md
@@ -767,7 +767,7 @@ int 123
         lastValidRound := uint64(txParams.LastRoundValid)
         tx, err := transaction.MakePaymentTxnWithFlatFee(
             addr, receiver, minFee, amount, firstValidRound, lastValidRound, note, "", genID, genHash)
-        txID, stx, err := crypto.SignLogicsigTransaction(lsig, tx)
+        txID, stx, err := crypto.SignLogicSigTransaction(lsig, tx)
         if err != nil {
             fmt.Printf("Signing failed with %v", err)
             return
@@ -1247,7 +1247,7 @@ The following example illustrates signing a transaction with a created logic sig
         tx, err := transaction.MakePaymentTxnWithFlatFee(
             sender, receiver, fee, amount, firstValidRound, lastValidRound,
             note, "", genID, genHash )
-        txID, stx, err := crypto.SignLogicsigTransaction(lsig, tx)
+        txID, stx, err := crypto.SignLogicSigTransaction(lsig, tx)
         if err != nil {
             fmt.Printf("Signing failed with %v", err)
             return

--- a/examples/smart_contracts/v2/go/accountDelegation.go
+++ b/examples/smart_contracts/v2/go/accountDelegation.go
@@ -113,7 +113,7 @@ func main() {
         sender, receiver, fee, amount, firstValidRound, lastValidRound,
         note, "", genID, genHash )
 
-    txID, stx, err := crypto.SignLogicsigTransaction(lsig, tx)
+    txID, stx, err := crypto.SignLogicSigTransaction(lsig, tx)
     if err != nil {
         fmt.Printf("Signing failed with %v", err)
         return

--- a/examples/smart_contracts/v2/go/contractAccount.go
+++ b/examples/smart_contracts/v2/go/contractAccount.go
@@ -104,7 +104,7 @@ func main() {
 	tx, err := transaction.MakePaymentTxnWithFlatFee(
 		addr, receiver, minFee, amount, firstValidRound, lastValidRound, note, "", genID, genHash)
 
-	txID, stx, err := crypto.SignLogicsigTransaction(lsig, tx)
+	txID, stx, err := crypto.SignLogicSigTransaction(lsig, tx)
 	if err != nil {
 		fmt.Printf("Signing failed with %v", err)
 		return

--- a/examples/smart_contracts/v2/go/dryrunDebugging.go
+++ b/examples/smart_contracts/v2/go/dryrunDebugging.go
@@ -159,7 +159,7 @@ func main() {
         sender, receiver, fee, amount, firstValidRound, lastValidRound,
         note, "", genID, genHash )
 
-    txID, stx, err := crypto.SignLogicsigTransaction(lsig, tx)
+    txID, stx, err := crypto.SignLogicSigTransaction(lsig, tx)
     if err != nil {
         fmt.Printf("Signing failed with %v", err)
         return


### PR DESCRIPTION
Updates go-algorand-sdk for for the rename of `SignLogicsigTransaction` in v2.0.0.
* Corresponding SDK change:  https://github.com/algorand/go-algorand-sdk/pull/445
* All v2.0.0 breaking changes discussed in https://github.com/algorand/go-algorand-sdk/issues/343 / https://github.com/algorand/go-algorand-sdk/pull/449.
* Changes made mechanically via `find . -type f -exec sed -i "" "s/SignLogicsigTransaction/SignLogicSigTransaction/g" {} \;`.
* PR to remain as a _draft_ until post v2.0.0 release.