### PR TITLE
Add conduit

### DIFF
--- a/.github/workflows/pr-generator.yml
+++ b/.github/workflows/pr-generator.yml
@@ -53,6 +53,22 @@ jobs:
           repository: algorand/indexer
           ref: ${{ inputs.indexer_version }}
           path: indexer
+          submodules: true
+
+      - name: Install golang
+        if: (contains(inputs.go_algorand_version, '-stable')) && (!contains(inputs.indexer_version, '-'))
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.17.9
+
+      - name: Generate conduit docs
+        if: (contains(inputs.go_algorand_version, '-stable')) && (!contains(inputs.indexer_version, '-'))
+        run: |
+          sudo apt update
+          sudo apt -y install python3 python3-pip python3-setuptools python3-wheel libboost-math-dev libffi-dev
+          cd ./indexer
+          make
+          cd ../
 
       - name: Download binaries
         if: (contains(inputs.go_algorand_version, '-stable')) && (!contains(inputs.indexer_version, '-'))
@@ -105,14 +121,3 @@ jobs:
         if: inputs.indexer_version != '' && !contains(inputs.indexer_version, '-')
         run: |
           echo "${{ inputs.indexer_version }}" > docs/.indexer.version
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
-        with:
-          path: docs
-          branch: "automatic-pr-go-algorand-${{ inputs.go_algorand_version }}-indexer-${{ inputs.indexer_version }}"
-          title: "Automatic update generated for go-algorand: ${{ inputs.go_algorand_version }} and indexer: ${{ inputs.indexer_version }}"
-          body: "Changes generated automatically by github action docs-generator."
-          reviewers: "nullun,barnjamin,ryanrfox"
-          delete-branch: true
-          base: staging

--- a/.github/workflows/pr-generator.yml
+++ b/.github/workflows/pr-generator.yml
@@ -68,6 +68,7 @@ jobs:
           sudo apt -y install python3 python3-pip python3-setuptools python3-wheel libboost-math-dev libffi-dev
           cd ./indexer
           make
+          rm -r ../get-details/conduit/* && cp ./conduit-docs/* ../get-details/conduit/
           cd ../
 
       - name: Download binaries

--- a/docs/clis/conduit/.pages
+++ b/docs/clis/conduit/.pages
@@ -1,0 +1,3 @@
+title: conduit
+arrange:
+ - conduit.md

--- a/docs/clis/conduit/conduit.md
+++ b/docs/clis/conduit/conduit.md
@@ -1,0 +1,53 @@
+title: conduit
+---
+## conduit
+
+
+
+run the conduit framework
+
+
+
+### Synopsis
+
+
+
+run the conduit framework
+
+
+
+```
+
+conduit [flags]
+
+```
+
+
+
+### Options
+
+
+
+```
+
+  -d, --data-dir string            set the data directory for the conduit binary
+
+  -h, --help                       help for conduit
+
+  -r, --next-round-override uint   set the starting round. Overrides next-round in metadata.json
+
+  -v, --version                    print the conduit version
+
+```
+
+
+
+### SEE ALSO
+
+
+
+* [conduit init](../init/)	 - initializes a sample data directory
+* [conduit list](../list/list/)	 - lists all plugins available to conduit
+
+
+

--- a/docs/clis/conduit/init.md
+++ b/docs/clis/conduit/init.md
@@ -1,0 +1,48 @@
+title: conduit init
+---
+## conduit init
+
+
+
+initializes a sample data directory
+
+
+
+### Synopsis
+
+
+
+initializes a Conduit data directory and conduit.yml file configured with the file_writer plugin. The config file needs to be modified slightly to include an algod address and token. Once ready, launch conduit with './conduit -d /path/to/data'.
+
+
+
+```
+
+conduit init [flags]
+
+```
+
+
+
+### Options
+
+
+
+```
+
+  -d, --data string   Full path to new data directory. If not set, a directory named 'data' will be created in the current directory.
+
+  -h, --help          help for init
+
+```
+
+
+
+### SEE ALSO
+
+
+
+* [conduit](../../conduit/conduit/)	 - run the conduit framework
+
+
+

--- a/docs/clis/conduit/list/.pages
+++ b/docs/clis/conduit/list/.pages
@@ -1,0 +1,3 @@
+title: conduit list
+arrange:
+ - list.md

--- a/docs/clis/conduit/list/exporters.md
+++ b/docs/clis/conduit/list/exporters.md
@@ -1,0 +1,38 @@
+title: conduit list exporters
+---
+## conduit list exporters
+
+
+
+usage detail for exporter plugins
+
+
+
+```
+
+conduit list exporters [flags]
+
+```
+
+
+
+### Options
+
+
+
+```
+
+  -h, --help   help for exporters
+
+```
+
+
+
+### SEE ALSO
+
+
+
+* [conduit list](../../list/list/)	 - lists all plugins available to conduit
+
+
+

--- a/docs/clis/conduit/list/importers.md
+++ b/docs/clis/conduit/list/importers.md
@@ -1,0 +1,38 @@
+title: conduit list importers
+---
+## conduit list importers
+
+
+
+usage detail for importer plugins
+
+
+
+```
+
+conduit list importers [flags]
+
+```
+
+
+
+### Options
+
+
+
+```
+
+  -h, --help   help for importers
+
+```
+
+
+
+### SEE ALSO
+
+
+
+* [conduit list](../../list/list/)	 - lists all plugins available to conduit
+
+
+

--- a/docs/clis/conduit/list/list.md
+++ b/docs/clis/conduit/list/list.md
@@ -1,0 +1,41 @@
+title: conduit list
+---
+## conduit list
+
+
+
+lists all plugins available to conduit
+
+
+
+```
+
+conduit list [flags]
+
+```
+
+
+
+### Options
+
+
+
+```
+
+  -h, --help   help for list
+
+```
+
+
+
+### SEE ALSO
+
+
+
+* [conduit](../../../conduit/conduit/)	 - run the conduit framework
+* [conduit list exporters](../exporters/)	 - usage detail for exporter plugins
+* [conduit list importers](../importers/)	 - usage detail for importer plugins
+* [conduit list processors](../processors/)	 - usage detail for processor plugins
+
+
+

--- a/docs/clis/conduit/list/processors.md
+++ b/docs/clis/conduit/list/processors.md
@@ -1,0 +1,38 @@
+title: conduit list processors
+---
+## conduit list processors
+
+
+
+usage detail for processor plugins
+
+
+
+```
+
+conduit list processors [flags]
+
+```
+
+
+
+### Options
+
+
+
+```
+
+  -h, --help   help for processors
+
+```
+
+
+
+### SEE ALSO
+
+
+
+* [conduit list](../../list/list/)	 - lists all plugins available to conduit
+
+
+

--- a/docs/get-details/conduit/exporters/filewriter.md
+++ b/docs/get-details/conduit/exporters/filewriter.md
@@ -1,0 +1,50 @@
+title: conduit exporters filewriter
+---
+
+
+### Config
+
+<table>
+
+<tr>
+
+<th>key</th><th>type</th><th>description</th>
+
+
+
+<tr><td>block-dir</td><td>string</td><td> <code>blocks-dir</code> is an optional path to a directory where block data should be
+
+	stored.<br/>
+
+	The directory is created if it doesn't exist.<br/>
+
+	If no directory is provided the default plugin data directory is used.
+
+</td></tr>
+
+
+
+<tr><td>filename-pattern</td><td>string</td><td> <code>filename-pattern</code> is the format used to write block files. It uses go
+
+	string formatting and should accept one number for the round.<br/>
+
+	If the file has a '.gz' extension, blocks will be gzipped.
+
+	Default:
+
+
+
+		"%[1]d_block.json"
+
+</td></tr>
+
+
+
+<tr><td>drop-certificate</td><td>bool</td><td><code>drop-certificate</code> is used to remove the vote certificate from the block data before writing files.
+
+</td></tr>
+
+</table>
+
+
+

--- a/docs/get-details/conduit/exporters/postgresql.md
+++ b/docs/get-details/conduit/exporters/postgresql.md
@@ -1,0 +1,46 @@
+title: conduit exporters postgresql
+---
+
+
+### ExporterConfig
+
+<table>
+
+<tr>
+
+<th>key</th><th>type</th><th>description</th>
+
+
+
+<tr><td>connection-string</td><td>string</td><td> <code>connectionstring</code> is the Postgresql connection string<br/>
+
+	See https://github.com/jackc/pgconn for more details
+
+</td></tr>
+
+
+
+<tr><td>max-conn</td><td>uint32</td><td> <code>max-conn</code> specifies the maximum connection number for the connection pool.<br/>
+
+	This means the total number of active queries that can be running concurrently can never be more than this.
+
+</td></tr>
+
+
+
+<tr><td>test</td><td>bool</td><td> <code>test</code> will replace an actual DB connection being created via the connection string,
+
+	with a mock DB for unit testing.
+
+</td></tr>
+
+
+
+<tr><td>delete-task</td><td>util.PruneConfigurations</td><td><code>delete-task</code> is the configuration for data pruning.
+
+</td></tr>
+
+</table>
+
+
+

--- a/docs/get-details/conduit/importers/algod.md
+++ b/docs/get-details/conduit/importers/algod.md
@@ -1,0 +1,28 @@
+title: conduit importers algod
+---
+
+
+### Config
+
+<table>
+
+<tr>
+
+<th>key</th><th>type</th><th>description</th>
+
+
+
+<tr><td>netaddr</td><td>string</td><td><code>netaddr</code> is the Algod network address. It must be either an <code>http</code> or <code>https</code> URL.
+
+</td></tr>
+
+
+
+<tr><td>token</td><td>string</td><td><code>token</code> is the Algod API endpoint token.
+
+</td></tr>
+
+</table>
+
+
+

--- a/docs/get-details/conduit/importers/filereader.md
+++ b/docs/get-details/conduit/importers/filereader.md
@@ -1,0 +1,52 @@
+title: conduit importers filereader
+---
+
+
+### Config
+
+<table>
+
+<tr>
+
+<th>key</th><th>type</th><th>description</th>
+
+
+
+<tr><td>block-dir</td><td>string</td><td><code>block-dir</code> is the path to a directory where block data is stored.
+
+</td></tr>
+
+
+
+<tr><td>retry-duration</td><td>time.Duration</td><td> <code>retry-duration</code> controls the delay between checks when the importer has caught up and is waiting for new blocks to appear.<br/>
+
+	The input duration will be interpreted in nanoseconds.
+
+</td></tr>
+
+
+
+<tr><td>retry-count</td><td>uint64</td><td> <code>retry-count</code> controls the number of times to check for a missing block
+
+	before generating an error. The retry count and retry duration should
+
+	be configured according the expected round time.
+
+</td></tr>
+
+
+
+<tr><td>filename-pattern</td><td>string</td><td> <code>filename-pattern</code> is the format used to find block files. It uses go string formatting and should accept one number for the round.
+
+	The default pattern is
+
+
+
+	"%[1]d_block.json"
+
+</td></tr>
+
+</table>
+
+
+

--- a/docs/get-details/conduit/processors/blockevaluator.md
+++ b/docs/get-details/conduit/processors/blockevaluator.md
@@ -1,0 +1,74 @@
+title: conduit processors blockevaluator
+---
+## The <code>block_processor</code> Plugin
+
+This plugin runs a local ledger, processing blocks passed to it, and adding
+
+
+
+### Config
+
+<table>
+
+<tr>
+
+<th>key</th><th>type</th><th>description</th>
+
+
+
+<tr><td>catchpoint</td><td>string</td><td> <code>catchpoint</code> to initialize the local ledger to.<br/>
+
+	For more data on ledger catchpoints, see the
+
+	<a hre=https://developer.algorand.org/docs/run-a-node/operations/catchup/>Algorand developer docs</a>
+
+</td></tr>
+
+
+
+<tr><td>ledger-dir</td><td>string</td><td><code>ledger-dir</code> is the directory which contains the ledger.
+
+</td></tr>
+
+
+
+<tr><td>algod-data-dir</td><td>string</td><td><code>algod-data-dir</code> is the algod data directory.
+
+</td></tr>
+
+
+
+<tr><td>algod-token</td><td>string</td><td><code>algod-token</code> is the API token for Algod usage.
+
+</td></tr>
+
+
+
+<tr><td>algod-addr</td><td>string</td><td><code>algod-addr</code> is the address of the Algod server
+
+</td></tr>
+
+</table>
+
+
+
+
+
+### Example Configs
+
+
+
+```yaml
+
+config:
+
+  - any:
+
+    - tag: ""
+
+	  expression: ""
+
+	  expression-type: ""
+
+```
+

--- a/docs/get-details/conduit/processors/filter.md
+++ b/docs/get-details/conduit/processors/filter.md
@@ -1,0 +1,90 @@
+title: conduit processors filter
+---
+
+
+### SubConfig
+
+<table>
+
+<tr>
+
+<th>key</th><th>type</th><th>description</th>
+
+
+
+<tr><td>tag</td><td>string</td><td> <code>tag</code> is the tag of the struct to analyze.<br/>
+
+	It can be of the form `txn.*` where the specific ending is determined by the field you wish to filter on.<br/>
+
+	It can also be a field in the ApplyData.
+
+</td></tr>
+
+
+
+<tr><td>expression-type</td><td>expression.FilterType</td><td> <code>expression-type</code> is the type of comparison applied between the field, identified by the tag, and the expression.<br/>
+
+	<ul>
+
+		<li>exact</li>
+
+		<li>regex</li>
+
+		<li>less-than</li>
+
+		<li>less-than-equal</li>
+
+		<li>greater-than</li>
+
+		<li>great-than-equal</li>
+
+		<li>equal</li>
+
+		<li>not-equal</li>
+
+	</ul>
+
+</td></tr>
+
+
+
+<tr><td>expression</td><td>string</td><td><code>expression</code> is the user-supplied part of the search or comparison.
+
+</td></tr>
+
+</table>
+
+
+
+
+
+### Config
+
+<table>
+
+<tr>
+
+<th>key</th><th>type</th><th>description</th>
+
+
+
+<tr><td>filters</td><td>[]map[string][]SubConfig</td><td> <code>filters</code> are a list of SubConfig objects with an operation acting as the string key in the map
+
+
+
+	filters:
+
+		- [any,all,none]:
+
+			expression: ""
+
+			expression-type: ""
+
+			tag: ""
+
+</td></tr>
+
+</table>
+
+
+

--- a/scripts/reformat-all-commands.sh
+++ b/scripts/reformat-all-commands.sh
@@ -23,6 +23,9 @@ CLI_TOOLS="~/go/bin/" # path to goal, algokey, etc.
 # CLI INDEXER
 ./reformat.py -doc-dir ../docs/clis/indexer/ -cmd $CLI_TOOLS/algorand-indexer
 
+# CLI CONDUIT
+./reformat.py -doc-dir ../docs/clis/conduit/ -cmd $CLI_TOOLS/conduit
+
 # REST KMD
 ./convert_swagger.py -target ../docs/rest-apis/kmd.md -specfile $GO_ALGORAND_SRC/daemon/kmd/api/swagger.json
 


### PR DESCRIPTION
Adds conduit CLI docs, and additionally generates the docs for conduit plugin configs.

The github workflow is a bit difficult to test. I've validated as much as I can locally that the scripts all work as intended, and I've tried to run the workflow locally with [act](https://github.com/nektos/act).

Sample plugin config page: 


![Screenshot 2022-12-20 at 9 26 27 AM](https://user-images.githubusercontent.com/10753834/208729182-846da19a-7cf9-4e78-80e2-65f46994d484.png)


