### PR TITLE
Use hyphens in testnet.md and mainnet.md

### DIFF
--- a/docs/get-details/algorand-networks/mainnet.md
+++ b/docs/get-details/algorand-networks/mainnet.md
@@ -1,10 +1,10 @@
 title: MainNet
-  
+
 # Version
-`v3.8.1.stable`
+`v3.13.2-stable`
 
 # Release Version
-https://github.com/algorand/go-algorand/releases/tag/v3.12.2-stable
+https://github.com/algorand/go-algorand/releases/tag/v3.13.2-stable
 
 # Genesis ID
 `mainnet-v1.0`

--- a/docs/get-details/algorand-networks/testnet.md
+++ b/docs/get-details/algorand-networks/testnet.md
@@ -1,7 +1,7 @@
 title: TestNet
-  
+
 # Version
-`v3.8.1.stable`
+`v3.13.2-stable`
 
 # Release Version
 https://github.com/algorand/go-algorand/releases/tag/v3.12.2-stable


### PR DESCRIPTION
## Summary
I noticed a comment @barnjamin had on one of the automated PRs.
The automation is looking for `v<version>-stable`. 
I'm replacing the previous version convention `.stable` to `-stable` here. This matches with `betanet.md`.

After this gets merged in, the next automated job should replace the version as expected.