### PR TITLE
Tool to generate node config markdown documentation from go-algorand source.

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,3 +27,17 @@ the markdown more pleasant with our mkdocs theme.
 ./convert_swagger.py -specfile ~/go/src/github.com/algorand/go-algorand/daemon/kmd/api/swagger.json  -target ../docs/reference/rest-apis/kmd.md
 ./convert_swagger.py -specfile ~/go/src/github.com/algorand/go-algorand/daemon/algod/api/algod.oas2.json  -target ../docs/reference/rest-apis/algod.md
 ```
+
+# config_json_gen
+
+Used to extract node config options from the go-algorand source. Markdown is written to stdout, warnings are written to stderr. To update the template, edit template.tmpl and rebuild the tool.
+
+Build tool:
+```
+go build .
+```
+
+Run:
+```
+./config_json_gen -path ~/algorand/go-algorand/ > config.md
+```

--- a/scripts/config_json_gen/main.go
+++ b/scripts/config_json_gen/main.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	_ "embed"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+//go:embed template.tmpl
+var configTemplate string
+
+// resolveLocalTemplate searches for the localTemplate.go file in the given path.
+func resolveLocalTemplate(pathStr string) (string, error) {
+	var pathTolocalTemplate string
+	err := filepath.Walk(pathStr, func(path string, info fs.FileInfo, err error) error {
+		// looking for a specific file.
+		if info.IsDir() {
+			return nil
+		}
+
+		if strings.HasSuffix(path, "localTemplate.go") {
+			pathTolocalTemplate = path
+		}
+		return nil
+	})
+	return pathTolocalTemplate, err
+}
+
+// DocParts are used to store data for each configuration
+type DocParts struct {
+	Name        string
+	Description string
+	Default     string
+	Type        string
+}
+
+// TemplateFields is passed to the go text template.
+type TemplateFields struct {
+	NodeDocs []DocParts
+}
+
+// parseDefault extracts the most recent default value from the tag.
+func parseDefault(tag string) string {
+	unwrap := func(str string, r byte) string {
+		if str[0] == r {
+			str = str[1:]
+		}
+		if len(str) > 0 && str[len(str)-1] == r {
+			str = str[:len(str)-1]
+		}
+		return str
+	}
+	tag = unwrap(tag, '`')
+	versions := strings.Split(tag, " ")
+	version := versions[len(versions)-1]
+	value := strings.Split(version, ":")[1]
+	value = unwrap(value, '"')
+	return value
+}
+
+// parseType converts the parameter type into a string.
+func parseType(x ast.Expr) string {
+	switch t := x.(type) {
+	case *ast.Ident:
+		return fmt.Sprintf("%s", t)
+	case *ast.SelectorExpr:
+		return fmt.Sprintf("%s.%s", t.X, t.Sel)
+	case *ast.MapType:
+		return fmt.Sprintf("map[%s]%s", t.Key, t.Value)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown configuration type: %s\n", t)
+		return fmt.Sprintf("%s", t)
+	}
+}
+
+// parseFile extracts the doc parts from a go file.
+func parseFile(filePath string) ([]DocParts, error) {
+	docs := make([]DocParts, 0)
+	src, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("parseFile: unable to read source: %w", err)
+	}
+
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, "", src, parser.ParseComments)
+	if err != nil {
+		return nil, fmt.Errorf("parseFile: unable to parse file: %w", err)
+	}
+
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.FuncDecl:
+			// skip functions
+			return false
+		case *ast.TypeSpec:
+			// skip everything but the "Local" type
+			return "Local" == x.Name.Name
+		case *ast.Field:
+			missingDoc := false
+			if len(x.Names) != 1 {
+				missingDoc = true
+			}
+			if x.Doc.Text() == "" {
+				missingDoc = true
+			}
+			if missingDoc {
+				for _, name := range x.Names {
+					fmt.Fprintf(os.Stderr, "missing comment for type: %s\n", name)
+				}
+				return true
+			}
+
+			// Grab common parts
+			doc := DocParts{
+				Name:        x.Names[0].Name,
+				Description: x.Doc.Text(),
+				Default:     parseDefault(x.Tag.Value),
+				Type:        parseType(x.Type),
+			}
+
+			docs = append(docs, doc)
+		}
+
+		return true
+	})
+
+	return docs, nil
+}
+
+func main() {
+	var pathStr string
+	flag.StringVar(&pathStr, "path", "", "Path to go-algorand, used to resolve localTemplate.go which is used for the parameter table.")
+	flag.Parse()
+
+	if pathStr == "" {
+		fmt.Fprintf(os.Stderr, "Must provide path to go-algorand with -path.")
+		os.Exit(1)
+	}
+
+	pathToLocalTemplate, err := resolveLocalTemplate(pathStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "An error occurred searching '%s': %s", pathStr, err)
+		os.Exit(1)
+	}
+
+	docs, err := parseFile(pathToLocalTemplate)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "An error occurred parsing file '%s': %s", pathToLocalTemplate, err)
+		os.Exit(1)
+	}
+
+	ut, err := template.New("configDoc").Parse(configTemplate)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "An error occurred parsing the template: %s", err)
+		os.Exit(1)
+	}
+
+	err = ut.Execute(os.Stdout, TemplateFields{NodeDocs: docs})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "An error occurred while executing the template: %s", err)
+		os.Exit(1)
+	}
+}

--- a/scripts/config_json_gen/template.tmpl
+++ b/scripts/config_json_gen/template.tmpl
@@ -1,0 +1,43 @@
+title: Node configuration settings
+Nodes can be configured with different options. These options will determine some of the capabilities of the node and whether it functions as a relay node or a non-relay node. This involves setting parameters in the configuration file for either the `algod` or `kmd` process.
+
+The configuration file (`config.json`) for the `algod` process is located in the node's `data` directory.
+If it does not exist, it needs to be created.
+A full example is provided as `config.json.example`.
+However, it is strongly recommended to only specify the parameters with non-default values in a custom `config.json` file, otherwise, when the algod software is updated, you may be using older non-recommended values for some of the parameters.
+
+Concretely, the `config.json` for an archival node should usually just be:
+```json
+{
+    "Archival": true
+}
+```
+
+The configuration file (`kmd_config.json`) for `kmd` is located in the nodes `data/kmd-version` (rename `kmd_config.json.example') directory.
+
+See [Node Types](../../run-a-node/setup/types.md) for more information.
+
+!!! info
+    All changes require the node to be restarted to take effect.
+
+!!! warning
+    Changing some parameter values can have drastic negative impact on performance. In particular, never set `IsIndexerActive` to `true`. This activates the very slow deprecated V1 indexer. If indexer is required, use the [V2 indexer](../../../get-details/indexer).
+
+# algod Configuration Settings
+The `algod` process configuration parameters are shown in the table below.
+
+| Property| Description | Default Value |
+|------|------|------|
+{{ range .NodeDocs }}| {{ .Name }} | {{ .Description }} | {{ .Default }} |
+{{ end }}
+
+
+
+# kmd Configuration Settings
+The `kmd` process configuration parameters are shown in the table below.
+
+| Property| Description | Default Value |
+|------|------|------|
+| address | Configures the address the node listens to for REST API calls. Specify an IP and port or just port. For example, 127.0.0.1:0 will listen on a random port on the localhost | 127.0.0.1:0 |
+| allowed_origins | Configures the whitelist for allowed domains which can access the kmd process. Specify an array of urls that will be white listed. ie {“allowed_origins”: [“https://othersite1.com“, “https://othersite2.com”]} | |
+| session_lifetime_secs | Number of seconds for session expirations.| 60 |


### PR DESCRIPTION
localTemplate.go needs to be modified before this tool will be really useful. The documentation is not all complete and some is completely missing. The tool attempts to write warnings to stdout, currently it prints the following:
```
missing comment for type: NetAddress
missing comment for type: MaxConnectionsPerIP
missing comment for type: TLSKeyFile
missing comment for type: CadaverDirectory
missing comment for type: RestWriteTimeoutSeconds
missing comment for type: SuggestedFeeBlockHistory
```

See the README for more information.