### PR TITLE
Fixing 58 bytes encoding.

### DIFF
--- a/docs/get-details/encoding.md
+++ b/docs/get-details/encoding.md
@@ -41,7 +41,7 @@ The encoding used for Addresses and Transaction Ids is [Base32](https://en.wikip
 
 In Algorand a [public key](../accounts/#transformation-public-key-to-algorand-address) is a 32 byte array. 
 
-The Address developers or users are typically shown is a 58 characters long string corresponding to a base32 encoding of the byte array of the public key + a checksum.
+The Address developers or users are typically shown is a 58 character long string corresponding to a base32 encoding of the byte array of the public key + a checksum.
 
 Given an address `4H5UNRBJ2Q6JENAXQ6HNTGKLKINP4J4VTQBEPK5F3I6RDICMZBPGNH6KD4`, encoding to and from the public key format can be done as follows:
 === "JavaScript"

--- a/docs/get-details/encoding.md
+++ b/docs/get-details/encoding.md
@@ -41,7 +41,7 @@ The encoding used for Addresses and Transaction Ids is [Base32](https://en.wikip
 
 In Algorand a [public key](../accounts/#transformation-public-key-to-algorand-address) is a 32 byte array. 
 
-The Address developers or users are typically shown is a 58 byte string corresponding to a base32 encoding of the byte array of the public key + a checksum.
+The Address developers or users are typically shown is a 58 characters long string corresponding to a base32 encoding of the byte array of the public key + a checksum.
 
 Given an address `4H5UNRBJ2Q6JENAXQ6HNTGKLKINP4J4VTQBEPK5F3I6RDICMZBPGNH6KD4`, encoding to and from the public key format can be done as follows:
 === "JavaScript"

--- a/docs/get-details/technical_faq.md
+++ b/docs/get-details/technical_faq.md
@@ -14,12 +14,12 @@ The limits applied at the protocol level are documented [here](/docs/get-details
 # Address Encoding/Decoding 
 
 An address comes in 2 forms:
-    1) encoded, 58 byte, looks something like `7K5TT4US7M3FM7L3XBJXSXLJGF2WCXPBV2YZJJO2FH46VCZOS3ICJ7E4QU`
+    1) encoded, 58 characters long, looks something like `7K5TT4US7M3FM7L3XBJXSXLJGF2WCXPBV2YZJJO2FH46VCZOS3ICJ7E4QU`
     2) decoded, 32 byte, looks something like `0xfabb39f292fb36567d7bb853795d693175615de1aeb194a5da29f9ea8b2e96d0` as hexadecimal
 
 You can translate from one to the other by using the SDK supplied methods. 
 
-For example, in python `encoding.encode_address` will convert the 32 byte version to the encoded 58 byte version and `encoding.decode_address` will perform the opposite translation.
+For example, in python `encoding.encode_address` will convert the 32 byte version to the encoded 58 characters long version and `encoding.decode_address` will perform the opposite translation.
 
 All SDKs have a similarly named method.
 

--- a/docs/get-details/technical_faq.md
+++ b/docs/get-details/technical_faq.md
@@ -19,7 +19,7 @@ An address comes in 2 forms:
 
 You can translate from one to the other by using the SDK supplied methods. 
 
-For example, in python `encoding.encode_address` will convert the 32 byte version to the encoded 58 characters long version and `encoding.decode_address` will perform the opposite translation.
+For example, in python `encoding.encode_address` will convert the 32 byte version to the encoded 58 character long version and `encoding.decode_address` will perform the opposite translation.
 
 All SDKs have a similarly named method.
 


### PR DESCRIPTION
If my math is correct, the `base32` encoding of the underlying `32+4` bytes of the private key results in 58 symbols accounting for padding.
`ceil((32+4)*8/5) = ceil(57,6) = 58`
The encoding shouldn't change the underlying number of bytes which is always 36 so I find that description confusing.
I propose we should use `symbols` or `characters` in the docs to describe the length of the encoding in `base32`