### PR TITLE
Bug Fix: release checker is pointing to incorrect indexer branch

### DIFF
--- a/.github/workflows/release-checker.yml
+++ b/.github/workflows/release-checker.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: algorand/indexer
-          ref: master
+          ref: main
           path: indexer
 
       - name: Get current documentation versions


### PR DESCRIPTION
# Summary

Indexer's default branch is now `main`. This script was erroring because `master` no longer existed.

# Testing

N/A - see if the checker succeeds now.
