### PR TITLE
Use vFuture version from go-algorand

### DIFF
--- a/scripts/reformat-all-commands.sh
+++ b/scripts/reformat-all-commands.sh
@@ -63,8 +63,7 @@ Opcodes by version:
 EOF
 
 opcode_files=(${GO_ALGORAND_SRC}/data/transactions/logic/TEAL_opcodes_v*.md)
-vfuture_version=$(grep '"LogicSigVersion": ' ${GO_ALGORAND_SRC}/data/transactions/logic/langspec_v1.json | awk '{print $2}' | tr -d '[,\n\r]')
-mainnet_version=$((${vfuture_version}-1))
+mainnet_version=$(grep '"LogicSigVersion": ' ${GO_ALGORAND_SRC}/data/transactions/logic/langspec_v1.json | awk '{print $2}' | tr -d '[,\n\r]')
 
 # Function to extract the opcode version number from the filename
 get_version_number() {
@@ -95,14 +94,14 @@ for ((i=${#sorted_files[@]}-1; i>=0; i--)); do
         sed -i.bak "s/\(\[[[:alnum:][:space:]]*\]\)(jsonspec\.md)/\1(..\/jsonspec.md)/g" "../docs/get-details/dapps/avm/teal/opcodes/v${version}.md"
         echo "  - v${version}.md" >> $pages_file
 
-        if [ $i -eq $(( $vfuture_version - 1)) ]; then
+        if [ $(($i + 1)) -gt $mainnet_version ]; then
             sed -i.bak '/^title:/a\
-            \
-            !!! Warning "This page contains the opcodes currently available in vFuture (not on Mainnet) and may change before release."\
-            ' "../docs/get-details/dapps/avm/teal/opcodes/v${version}.md"
+\
+!!! Warning "This page contains the opcodes currently available in vFuture (not on Mainnet) and may change before release."\
+' "../docs/get-details/dapps/avm/teal/opcodes/v${version}.md"
         fi
 
-        if [ $i -eq $(( $mainnet_version - 1)) ]; then
+        if [ $(($i + 1)) -eq $mainnet_version ]; then
           echo "- [v${version} - Current version on Mainnet](v${version}.md)" >> "$index_file"
         else
           echo "- [v${version}](v${version}.md)" >> $index_file

--- a/scripts/reformat-all-commands.sh
+++ b/scripts/reformat-all-commands.sh
@@ -4,7 +4,6 @@
 GO_ALGORAND_SRC=$1
 INDEXER_SRC=$2
 CLI_TOOLS="~/go/bin/" # path to goal, algorand-indexer, algokey, etc.
-CLI_TOOLS="~/.asdf/shims/"
 
 # CLI GOAL
 ./reformat.py -doc-dir ../docs/clis/goal/ -cmd $CLI_TOOLS/goal

--- a/scripts/reformat-all-commands.sh
+++ b/scripts/reformat-all-commands.sh
@@ -4,6 +4,7 @@
 GO_ALGORAND_SRC=$1
 INDEXER_SRC=$2
 CLI_TOOLS="~/go/bin/" # path to goal, algorand-indexer, algokey, etc.
+CLI_TOOLS="~/.asdf/shims/"
 
 # CLI GOAL
 ./reformat.py -doc-dir ../docs/clis/goal/ -cmd $CLI_TOOLS/goal
@@ -62,7 +63,7 @@ Opcodes by version:
 EOF
 
 opcode_files=(${GO_ALGORAND_SRC}/data/transactions/logic/TEAL_opcodes_v*.md)
-vfuture_version=$(grep 'vFuture.LogicSigVersion =' ${GO_ALGORAND_SRC}/config/consensus.go | awk '{print $3}' | tr -d '\r')
+vfuture_version=$(grep '"LogicSigVersion": ' ${GO_ALGORAND_SRC}/data/transactions/logic/langspec_v1.json | awk '{print $2}' | tr -d '[,\n\r]')
 mainnet_version=$((${vfuture_version}-1))
 
 # Function to extract the opcode version number from the filename
@@ -95,15 +96,10 @@ for ((i=${#sorted_files[@]}-1; i>=0; i--)); do
         echo "  - v${version}.md" >> $pages_file
 
         if [ $i -eq $(( $vfuture_version - 1)) ]; then
-            # The most efficient POSIX-compliant way to insert a line that I could find.
-            ed -s "../docs/get-details/dapps/avm/teal/opcodes/v${version}.md" <<EOF
-3i
-!!! Warning "This page contains the opcodes currently available in vFuture (not on Mainnet) and may change before release."
-
-.
-w
-q
-EOF
+            sed -i.bak '/^title:/a\
+            \
+            !!! Warning "This page contains the opcodes currently available in vFuture (not on Mainnet) and may change before release."\
+            ' "../docs/get-details/dapps/avm/teal/opcodes/v${version}.md"
         fi
 
         if [ $i -eq $(( $mainnet_version - 1)) ]; then

--- a/scripts/reformat-all-commands.sh
+++ b/scripts/reformat-all-commands.sh
@@ -98,7 +98,7 @@ for ((i=${#sorted_files[@]}-1; i>=0; i--)); do
             # The most efficient POSIX-compliant way to insert a line that I could find.
             ed -s "../docs/get-details/dapps/avm/teal/opcodes/v${version}.md" <<EOF
 3i
-!!! Warning "This page contains the opcodes currently available in vFuture and may change before release."
+!!! Warning "This page contains the opcodes currently available in vFuture (not on Mainnet) and may change before release."
 
 .
 w
@@ -107,7 +107,7 @@ EOF
         fi
 
         if [ $i -eq $(( $mainnet_version - 1)) ]; then
-          echo "- [v${version} - Current Version](v${version}.md)" >> "$index_file"
+          echo "- [v${version} - Current version on Mainnet](v${version}.md)" >> "$index_file"
         else
           echo "- [v${version}](v${version}.md)" >> $index_file
         fi


### PR DESCRIPTION
The latest version isn't always the current mainnet version, so instead use vFuture - 1 as mainnet, and insert a warning into the vFuture opcode docs about potential changes.