### PR TITLE
Fix tag ref for github actions

### DIFF
--- a/.github/workflows/pr-generator.yml
+++ b/.github/workflows/pr-generator.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: algorand/indexer
-          ref: ${{ inputs.indexer_version }}
+          ref: v${{ inputs.indexer_version }}
           path: indexer
           submodules: true
 


### PR DESCRIPTION
Since Indexer 3 a 'v' is prefixed at the start